### PR TITLE
fix to work with PB import directive

### DIFF
--- a/lib/protobuf/compiler/nodes.rb
+++ b/lib/protobuf/compiler/nodes.rb
@@ -57,7 +57,7 @@ require 'protobuf/message/extend'
       end
 
       def accept_message_visitor(visitor)
-        visitor.write("require_relative '#{visitor.required_message_from_proto(@path)}'")
+        visitor.write("require '#{visitor.required_message_from_proto(@path)}'")
       end
 
       def accept_descriptor_visitor(visitor)


### PR DESCRIPTION
Hello,
this is the small fix for the visitor.rb file to generate the appropriate `require` string for the *.pb.rb file. 

Current version causes the "cannot load such file #{file name}" on line 114 of protobuf / lib / protobuf / compiler / visitors.rb
It returns:
require 'ClassName.pb'
and Class.new.class_eval call causes the error above.

Thanks
