### PR TITLE
make Protobuf::EnumValue look like a Fixnum so arel visitor will work

### DIFF
--- a/lib/protobuf/enum_value.rb
+++ b/lib/protobuf/enum_value.rb
@@ -6,6 +6,11 @@ module Protobuf
 
     attr_reader :parent_class, :name, :value
 
+    # Overriding the class so ActiveRecord/Arel visitor will visit the enum as a Fixnum
+    def class
+      Fixnum
+    end
+
     def initialize(parent_class, name, value)
       @parent_class = parent_class
       @name = name
@@ -14,7 +19,7 @@ module Protobuf
     end
 
     def inspect
-      "\#<#{self.class} #{@parent_class}::#{@name}=#{@value}>"
+      "\#<Protobuf::EnumValue #{@parent_class}::#{@name}=#{@value}>"
     end
 
     def to_hash_value
@@ -22,7 +27,7 @@ module Protobuf
     end
 
     def to_s
-      @name.to_s
+      to_hash_value.to_s
     end
   end
 end

--- a/spec/lib/protobuf/enum_value_spec.rb
+++ b/spec/lib/protobuf/enum_value_spec.rb
@@ -3,11 +3,12 @@ require 'spec_helper'
 describe Protobuf::EnumValue do
 
 	subject { Test::EnumTestType::ONE }
+  its(:class) { should eq Fixnum }
 	its(:parent_class) { should eq Test::EnumTestType }
 	its(:name) { should eq :ONE }
 	its(:value) { should eq 1 }
 	its(:to_hash_value) { should eq 1 }
-	its(:to_s) { should eq "ONE" }
+	its(:to_s) { should eq "1" }
 	its(:inspect) { should eq '#<Protobuf::EnumValue Test::EnumTestType::ONE=1>' }
 
 end


### PR DESCRIPTION
I know you have been looking at doing a custom arel node, but this commit makes it visitable as a Fixnum (which I think is the behavior we want).

@localshred 
