### PR TITLE
Add rescue_from support to filters

### DIFF
--- a/lib/protobuf/rpc/service_filters.rb
+++ b/lib/protobuf/rpc/service_filters.rb
@@ -26,6 +26,20 @@ module Protobuf
           @filters ||= Hash.new { |h,k| h[k] = [] }
         end
 
+        # Filters hash keyed based on filter type (e.g. :before, :after, :around),
+        # whose values are Sets.
+        #
+        def rescue_filters
+          @rescue_filters ||= {}
+        end
+
+        def rescue_from(*ex_klasses, &block)
+          options = ex_klasses.last.is_a?(Hash) ? ex_klasses.pop : {}
+          callable = options.delete(:with) { block }
+          raise ArgumentError, 'Option :with missing from rescue_from options' if callable.nil?
+          ex_klasses.each { |ex_klass| rescue_filters[ex_klass] = callable }
+        end
+
         private
 
         def define_filter(type, filter, options = {})
@@ -146,6 +160,10 @@ module Protobuf
           return ! skip_invoke
         end
 
+        def rescue_filters
+          self.class.rescue_filters
+        end
+
         # Loop over the unwrapped filters and invoke them. An unwrapped filter
         # is either a before or after filter, not an around filter.
         #
@@ -205,30 +223,36 @@ module Protobuf
         # be used instead of the other run methods directly.
         #
         def run_filters(rpc_method)
-          continue = run_unwrapped_filters(filters[:before], rpc_method, true)
-          if continue
-            run_around_filters(rpc_method)
-            run_unwrapped_filters(filters[:after], rpc_method)
+          run_rescue_filters do
+            continue = run_unwrapped_filters(filters[:before], rpc_method, true)
+            if continue
+              run_around_filters(rpc_method)
+              run_unwrapped_filters(filters[:after], rpc_method)
+            end
+          end
+        end
+
+        def run_rescue_filters
+          if rescue_filters.keys.empty?
+            yield
+          else
+            begin
+              yield
+            rescue *rescue_filters.keys => ex
+              call_or_send(rescue_filters[ex.class], ex)
+            end
           end
         end
 
         # Call the object if it is callable, otherwise invoke the method using
         # __send__ assuming that we respond_to it. Return the call's return value.
         #
-        def call_or_send(callable, &block)
+        def call_or_send(callable, *args, &block)
           return_value = case
                          when callable.respond_to?(:call) then
-                           if callable.arity == 1
-                             callable.call(self, &block)
-                           else
-                             callable.call(&block)
-                           end
+                           callable.call(self, *args, &block)
                          when respond_to?(callable, true) then
-                           if method(callable).arity == 1
-                             __send__(callable, self, &block)
-                           else
-                             __send__(callable, &block)
-                           end
+                           __send__(callable, *args, &block)
                          else
                            raise "Object #{callable} is not callable"
                          end


### PR DESCRIPTION
Rescue filters can be addressed by registering filters with `rescue_from`. Rescue from differs from a simple around filter in that it will run around the entire service method, including before and after filters. Around filters run between the before and after filters and hence won't truly catch everything that the service may raise.

Rescue from will not, however, be run in the context of the server process or any (de)serialization routines. Keep that in mind. As is the case with filters, rescue filters will be run in the context of the service instance, so you have access to `respond_with`, `rpc_failed`, `request`, `response`, as well as any instance-level state.

Define the rescue filter by providing the exception class (or classes) you wish to handle, and then an instance method name via the `:with` param.

``` ruby
class Foo::UserService
  rescue_from ActiveRecord::RecordNotFound, :with => :record_not_found

  def show
    # ... some code that throws the above exception but does not explicitly handle it
  end

  private

  def record_not_found(ex)
    log_error { ex.message }
    log_debug { ex.backtrace.join("\n") }
  end
end
```

Alternatively you can provide a callable object to `:with` or simply pass a block. In this case you should accept two parameters to your block, the service object and the exception.

``` ruby
class Foo::UserService
  rescue_from ActiveRecord::RecordNotFound do |service, ex|
    service.rpc_failed 'Service failed with message %s' % ex.message
    log_error { ex.message }
    log_debug { ex.backtrace.join("\n") }
  end

  # ... snip
end
```

You can also pass multiple exception classes to rescue from in a single filter registration:

``` ruby
class Foo::UserService
  rescue_from ActiveRecord::RecordNotFound, CustomException1, NoMethodError, StandardError, :with => :handle_exceptions

  # ... snip
end
```

Keep in mind that it doesn't make sense to have a rescue in your rpc method if you have also registered to rescue for any exceptions. Choose one or the other. And choose wisely.

---

Thoughts?
