### PR TITLE
use inproc socket for backend and cleanup broker

### DIFF
--- a/lib/protobuf/rpc/servers/zmq/broker.rb
+++ b/lib/protobuf/rpc/servers/zmq/broker.rb
@@ -12,10 +12,10 @@ module Protobuf
         # Constructor
         #
         def initialize(options = {})
-          @available_workers = []
+          @options = options
           @context = ::ZMQ::Context.new
-          @frontend = setup_frontend(options)
-          @backend = setup_backend(options)
+          @frontend = setup_frontend
+          @backend = setup_backend
           @poller = ::ZMQ::Poller.new
           @poller.register(frontend, ::ZMQ::POLLIN)
           @poller.register(backend, ::ZMQ::POLLIN)
@@ -25,86 +25,54 @@ module Protobuf
         # Instance Methods
         #
         def poll
-          if available_workers.size > 0
-            poller.register(frontend, ::ZMQ::POLLIN) if poller.size < 2
-          else
-            poller.delete(frontend)            
-          end
-
           poller.poll(1000)
           poller.readables.each do |socket|
             case socket
             when frontend then
-              move_to_backend(socket)
+              zmq_error_check(frontend.recv_strings(messages = []))
+              zmq_error_check(backend.send_strings(messages))
             when backend then
-              move_to_frontend(socket)
+              zmq_error_check(backend.recv_strings(messages = []))
+              zmq_error_check(frontend.send_strings(messages))
             end
           end
         end
 
         def teardown
-          frontend.close
-          backend.close
+          zmq_error_check(frontend.close)
+          zmq_error_check(backend.close)
           context.terminate
         end
 
+        def frontend_addr
+          unless @frontend_addr
+            host = @options[:host]
+            port = @options[:port]
+
+            @frontend_addr = "tcp://#{resolve_ip(host)}:#{port}"
+          end
+
+          @frontend_addr
+        end
+
+        def backend_addr
+          "inproc://backend"
+        end
+
         private
-
-          def move_to_backend(socket)
-            message_array = []
-            zmq_error_check(socket.recv_strings(message_array))
-
-            backend_message_set = [
-              available_workers.shift, # Worker UUID for router
-              "",
-              message_array[0], # Client UUID for return value
-              "",
-              message_array[2] # Client Message payload (request)
-            ]
-
-            zmq_error_check(backend.send_strings(backend_message_set))
-          end
-
-          def move_to_frontend(socket)
-            message_array = []
-            zmq_error_check(socket.recv_strings(message_array))
-
-            # Push UUID of socket on the available workers queue
-            available_workers << message_array[0]
-
-            # messages should be [ "uuid of socket", "", "READY_MESSAGE || uuid of client socket"]
-            unless message_array[2] == ::Protobuf::Rpc::Zmq::WORKER_READY_MESSAGE
-              frontend_message_set = [
-                message_array[2], # client UUID
-                "",
-                message_array[4] # Reply payload
-              ]
-
-              zmq_error_check(frontend.send_strings(frontend_message_set))
-            end
-          end
-
-          def setup_backend(options = {})
-            dealer_options = options.merge(:port => options[:port] + 1)
-            host = dealer_options[:host]
-            port = dealer_options[:port]
-
-            zmq_backend = context.socket(::ZMQ::ROUTER)
-            zmq_error_check(zmq_backend.bind(bind_address(host, port)))
+          def setup_backend
+            zmq_backend = context.socket(::ZMQ::DEALER)
+            zmq_error_check(zmq_backend.bind(backend_addr))
             zmq_backend
           end
 
-          def setup_frontend(options = {})
-            host = options[:host]
-            port = options[:port]
-
+          def setup_frontend
             zmq_frontend = context.socket(::ZMQ::ROUTER)
-            zmq_error_check(zmq_frontend.bind(bind_address(host, port)))
+            zmq_error_check(zmq_frontend.bind(frontend_addr))
             zmq_frontend
           end
 
           def bind_address(host, port)
-            "tcp://#{resolve_ip(host)}:#{port}"
           end
       end
     end


### PR DESCRIPTION
By using an inproc socket for backend communication we can speed up the
interprocess communication. From the 0MQ guide:

> The inter-thread transport, inproc, is a connected signaling
> transport. It is much faster than tcp or ipc.

I also cleaned up the implementation of the broker. It was juggling more
data than it needed to--replicating functionality the router and dealer
sockets already provide. This removes the workers ready message that was
being sent to the broker, but it didn't appear to be useful. The broker
doesn't need to know how many workers are waiting for jobs. If there are
zero, the call to Broker#poll will block until the first worker is
ready. This could have caused the process to hang on shutdown. I
alleviated this by moving the call to Broker#teardown into the
Server#stop method. Any blocking calls will return immediately when the
teardown function closes the brokers sockets.
