### PR TITLE
Only require used active_support extensions.

### DIFF
--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -2,7 +2,10 @@ require 'logger'
 require 'socket'
 require 'pp'
 require 'stringio'
-require 'active_support/all'
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/object/try'
+require 'active_support/inflector'
+require 'active_support/json'
 
 module Protobuf
 


### PR DESCRIPTION
An application I'm dealing with has its own Hash#slice implementation that active_support/all was indirectly blowing away once protobuf was required I think.

Though I'd rather core classes in an application not be indirectly modified via a third party library this patch explicitly requires only used active_support extensions rather than loading (or autoloading) everything in active_support/all.

Cheers,
Shane.
