### PR TITLE
Only require used active_support extensions.

### DIFF
--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -2,7 +2,16 @@ require 'logger'
 require 'socket'
 require 'pp'
 require 'stringio'
-require 'active_support/all'
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/object/try'
+require 'active_support/inflector'
+require 'active_support/json'
+
+begin # master
+require 'active_support/core_ext/object/deep_dup'
+rescue LoadError # 3.2.x
+require 'active_support/core_ext/hash/deep_dup'
+end
 
 module Protobuf
 


### PR DESCRIPTION
As requested pull request for 2-7-stable. deep_dup has moved locations in active_support between 3-2-stable and master so I've included both for now, I hope that's ok.

An application I'm dealing with has its own Hash#slice implementation that active_support/all was indirectly blowing away once protobuf was required I think.

Though I'd rather core classes in an application not be indirectly modified via a third party library this patch explicitly requires only used active_support extensions rather than loading (or autoloading) everything in active_support/all.

Cheers,
Shane.
