### PR TITLE
Add TTIN signal to zmq server to increment threads

### DIFF
--- a/lib/protobuf/rpc/servers/zmq/server.rb
+++ b/lib/protobuf/rpc/servers/zmq/server.rb
@@ -64,7 +64,7 @@ module Protobuf
         def self.stop
           @running = false
 
-          self.threads.each do |t|
+          @threads.each do |t|
             t.join
           end
         end


### PR DESCRIPTION
To increase the size of the worker threads in a running rpc_server
process you can simply send the process a TTIN signal and an additional
worker will be pushed into the pool.

  Example

```
# If pid of rpc_server is 3442...
kill -TTIN 3442
```
