### PR TITLE
Check for dup field tags/names in define_field

### DIFF
--- a/lib/protobuf/exceptions.rb
+++ b/lib/protobuf/exceptions.rb
@@ -5,4 +5,5 @@ module Protobuf
   class TagCollisionError < Error; end
   class SerializationError < StandardError; end
   class FieldNotDefinedError < StandardError; end
+  class DuplicateFieldNameError < StandardError; end
 end

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -27,8 +27,14 @@ module Protobuf
       field_array = options[:extension] ? extension_fields : fields
       field_name_hash = options[:extension] ? extension_field_name_to_tag : field_name_to_tag
 
-      if field_array[tag]
-        raise TagCollisionError, %!{Field number #{tag} has already been used in "#{self.name}" by field "#{fname}".!
+      previous_tag_field = get_field_by_tag(tag) || get_ext_field_by_tag(tag)
+      if previous_tag_field
+        raise TagCollisionError, %!Field number #{tag} has already been used in "#{self.name}" by field "#{fname}".!
+      end
+
+      previous_name_field = get_field_by_name(fname) || get_ext_field_by_name(fname)
+      if previous_name_field
+        raise DuplicateFieldNameError, %!Field name #{fname} has already been used in "#{self.name}".!
       end
 
       field_definition = ::Protobuf::Field.build(self, rule, type, fname, tag, options)

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -2,6 +2,54 @@ require 'spec_helper'
 
 describe Protobuf::Message do
 
+  describe '.define_field' do
+    context 'when defining a field with a tag that has already been used' do
+      it 'raises a TagCollisionError' do
+        expect {
+          Class.new(Protobuf::Message) do
+            define_field :optional, ::Protobuf::Field::Int32Field, :foo, 1, {}
+            define_field :optional, ::Protobuf::Field::Int32Field, :bar, 1, {}
+          end
+        }.to raise_error(Protobuf::TagCollisionError, /Field number 1 has already been used/)
+      end
+    end
+
+    context 'when defining an extension field with a tag that has already been used' do
+      it 'raises a TagCollisionError' do
+        expect {
+          Class.new(Protobuf::Message) do
+            extensions 100...110
+            define_field :optional, ::Protobuf::Field::Int32Field, :foo, 100, {}
+            define_field :optional, ::Protobuf::Field::Int32Field, :bar, 100, :extension => true
+          end
+        }.to raise_error(Protobuf::TagCollisionError, /Field number 100 has already been used/)
+      end
+    end
+
+    context 'when defining a field with a name that has already been used' do
+      it 'raises a DuplicateFieldNameError' do
+        expect {
+          Class.new(Protobuf::Message) do
+            define_field :optional, ::Protobuf::Field::Int32Field, :foo, 1, {}
+            define_field :optional, ::Protobuf::Field::Int32Field, :foo, 2, {}
+          end
+        }.to raise_error(Protobuf::DuplicateFieldNameError, /Field name foo has already been used/)
+      end
+    end
+
+    context 'when defining an extension field with a name that has already been used' do
+      it 'raises a DuplicateFieldNameError' do
+        expect {
+          Class.new(Protobuf::Message) do
+            extensions 100...110
+            define_field :optional, ::Protobuf::Field::Int32Field, :foo, 1, {}
+            define_field :optional, ::Protobuf::Field::Int32Field, :foo, 100, :extension => true
+          end
+        }.to raise_error(Protobuf::DuplicateFieldNameError, /Field name foo has already been used/)
+      end
+    end
+  end
+
   describe '#initialize' do
     it "initializes the enum getter to 0" do
       test_enum = Test::EnumTestMessage.new

--- a/spec/support/test/multi_field_extensions.pb.rb
+++ b/spec/support/test/multi_field_extensions.pb.rb
@@ -1,0 +1,36 @@
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf/message'
+
+module Test
+
+  ##
+  # Message Classes
+  #
+  class Header < ::Protobuf::Message
+    class Type < ::Protobuf::Enum
+      define :PayloadTypeA, 1
+      define :PayloadTypeB, 2
+    end
+    
+  end
+  class PayloadA < ::Protobuf::Message; end
+  class PayloadB < ::Protobuf::Message; end
+  
+  ##
+  # Message Fields
+  #
+  class Header
+    required ::Test::Header::Type, :type, 1
+    
+    # Extension Fields
+    extensions 100...536870912
+    optional ::Test::PayloadA, :payload, 100, :extension => true
+    # UNCOMMENT TO TEST FAILING WITH MULTIPLE FIELDS
+    # optional ::Test::PayloadB, :payload, 101, :extension => true
+  end
+  
+  
+end
+

--- a/spec/support/test/multi_field_extensions.proto
+++ b/spec/support/test/multi_field_extensions.proto
@@ -1,0 +1,23 @@
+package test;
+
+message Header {
+  extensions 100 to max;
+  enum Type   {
+    PayloadTypeA = 1;
+    PayloadTypeB = 2;
+  }
+  required Type type = 1;
+}
+
+message PayloadA {
+  extend Header {
+    optional PayloadA payload = 100;
+  }
+}
+
+message PayloadB {
+  extend Header {
+  // UNCOMMENT TO TEST FAILING WITH MULTIPLE FIELDS
+  //  optional PayloadB payload = 101;
+  }
+}


### PR DESCRIPTION
The rprotoc generator is duped by duplicate field names when you extend the
same message from within different scopes:

message Foo {
 ...
}

message Bar {
 extend Foo {
   optional Protobuf::Field::Int32Field, :foo, 100
 }
}

message Baz {
 extend Foo {
   optional Protobuf::Field::Int32Field, :foo, 101
 }
}

The fix is simply to check on each Message.define_field call for fields that
already exist with the same name (regular or extension fields).

Fixes #70
