### PR TITLE
Accept values that respond to `to_f` in FloatField.

### DIFF
--- a/lib/protobuf/field/float_field.rb
+++ b/lib/protobuf/field/float_field.rb
@@ -4,10 +4,6 @@ module Protobuf
   module Field
     class FloatField < BaseField
       def self.default; 0.0; end
-      def self.max;  1.0/0; end
-      def self.min; -1.0/0; end
-      def max;  1.0/0; end
-      def min; -1.0/0; end
 
       def wire_type
         WireType::FIXED32
@@ -22,7 +18,7 @@ module Protobuf
       end
 
       def acceptable?(val)
-        (val > min || val < max) rescue false
+        val.respond_to?(:to_f)
       end
     end
   end


### PR DESCRIPTION
The checking for acceptable FloatField values was verifying that values fell between -Infinity and Infinity. This worked for any number object, including BigDecimal in MRI <= 1.9.2 & JRuby. In MRI 1.9.3+, setting a BigDecimal raised a type error.

Since BigDecimal values pack the same way as Float values and their aren't min/max values for double/float fields in Protocol Buffers, a simple `respond_to?(:to_f)` call will suffice when checking for acceptable values.

I'm pulling into the 2.7 branch since 2.8 is currently out in beta.

Closes #90.
