### PR TITLE
Add fallback support for activesupport 2

### DIFF
--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -3,7 +3,16 @@ require 'socket'
 require 'pp'
 require 'stringio'
 require 'active_support/core_ext/object/blank'
-require 'active_support/core_ext/object/try'
+require 'active_support/version'
+
+if ActiveSupport::VERSION::MAJOR > 2
+  require 'active_support/core_ext/object/try'
+else
+  require 'active_support/core_ext/module/delegation'
+  require 'active_support/core_ext/kernel/reporting'
+  require 'active_support/core_ext/try'
+end
+
 require 'active_support/inflector'
 require 'active_support/json'
 


### PR DESCRIPTION
Looks like the dependencies into activesupport are specific to versions > 2, even though the gem is nonspecific about the version it requires. This made it so that I couldn't use protobuf with a rails 2 app. The changes I made work under both versions of activesupport according to the specs.
