### PR TITLE
Fix default service directory address

### DIFF
--- a/lib/protobuf/rpc/service_directory.rb
+++ b/lib/protobuf/rpc/service_directory.rb
@@ -12,7 +12,7 @@ module Protobuf
       include ::Singleton
       include ::Protobuf::Logger::LogMethods
 
-      DEFAULT_ADDRESS = "255.255.255.255"
+      DEFAULT_ADDRESS = "0.0.0.0"
       DEFAULT_PORT = 53000
       DEFAULT_TIMEOUT = 1
 


### PR DESCRIPTION
Using 255.255.255.255 does not work on osx.

---

I opened this against master. If you want it against 2.8-stable instead let me know.
