### PR TITLE
Revert the change to the default timeout

### DIFF
--- a/lib/protobuf/rpc/connectors/base.rb
+++ b/lib/protobuf/rpc/connectors/base.rb
@@ -17,7 +17,7 @@ module Protobuf
         :request        => nil,           # The request object sent by the client
         :request_type   => nil,           # The request type expected by the client
         :response_type  => nil,           # The response type expected by the client
-        :timeout        => 15,            # The default timeout for the request, also handled by client.rb
+        :timeout        => 300,           # The default timeout for the request, also handled by client.rb
         :client_host    => nil            # The hostname or address of this client
       }
 


### PR DESCRIPTION
This change effectively reduced the timeout from 5 minutes to 5 seconds (15 / 5). The assumption being that a request taking longer than 5 seconds would be indicative of a problem, but in practice, some users have long running requests that may take more than a minute to respond, and reissuing the request after 5 seconds is potentially dangerous in those situations.
