### PR TITLE
Fix address in use errors on OSX

### DIFF
--- a/lib/protobuf/rpc/service_directory.rb
+++ b/lib/protobuf/rpc/service_directory.rb
@@ -169,6 +169,11 @@ module Protobuf
       def init_socket
         @socket = UDPSocket.new
         @socket.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, true)
+
+        if defined?(::Socket::SO_REUSEPORT)
+          @socket.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEPORT, true)
+        end
+
         @socket.bind(self.class.address, self.class.port.to_i)
       end
 


### PR DESCRIPTION
OSX users were getting failures when trying to bind more than one client
to the broadcast port. This change sets the REUSEPORT socket option on
platforms where it is available.
