### PR TITLE
Dup string value when encoding if it is frozen

### DIFF
--- a/lib/protobuf/field/string_field.rb
+++ b/lib/protobuf/field/string_field.rb
@@ -10,8 +10,9 @@ module Protobuf
         bytes
       end
 
+      # TODO: make replace character configurable?
       def encode(value)
-        # TODO: make replace character configurable?
+        value = value.dup if value.frozen?
         value.encode!(::Protobuf::Field::StringField::ENCODING, :invalid => :replace, :undef => :replace, :replace => "")
         value.force_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
 

--- a/spec/lib/protobuf/field/string_field_spec.rb
+++ b/spec/lib/protobuf/field/string_field_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe ::Protobuf::Field::StringField do
+  describe '#encode' do
+    context 'when a repeated string field contains frozen strings' do
+      it 'does not raise an encoding error' do
+        expect {
+          frozen_strings = [ "foo".freeze, "bar".freeze, "baz".freeze ]
+          ::Test::ResourceFindRequest.encode(:name => 'resource', :widgets => frozen_strings)
+        }.not_to raise_error
+      end
+    end
+
+    context 'when a repeated bytes field contains frozen strings' do
+      it 'does not raise an encoding error' do
+        expect {
+          frozen_strings = [ "foo".freeze, "bar".freeze, "baz".freeze ]
+          ::Test::ResourceFindRequest.encode(:name => 'resource', :widget_bytes => frozen_strings)
+        }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/support/test/resource.pb.rb
+++ b/spec/support/test/resource.pb.rb
@@ -49,6 +49,8 @@ module Test
   class ResourceFindRequest
     required ::Protobuf::Field::StringField, :name, 1
     optional ::Protobuf::Field::BoolField, :active, 2
+    repeated ::Protobuf::Field::StringField, :widgets, 3
+    repeated ::Protobuf::Field::BytesField, :widget_bytes, 4
   end
 
   class ResourceSleepRequest

--- a/spec/support/test/resource.proto
+++ b/spec/support/test/resource.proto
@@ -10,6 +10,8 @@ enum StatusType {
 message ResourceFindRequest {
   required string name = 1;
   optional bool active = 2;
+  repeated string widgets = 3;
+  repeated bytes widget_bytes = 4;
 }
 
 message ResourceSleepRequest {


### PR DESCRIPTION
String#encode! will raise a RuntimeError if the string instance is frozen.

The normal string setter for required or optional string fields already dups
the incoming string to avoid reference issues. However when the field is a
repeated string field the assigned array is dup'ed, but ruby keeps any
string's frozen state.

The fix is simply to dup any string value when we go to encode if it is
frozen.
