### PR TITLE
StringField get wrong encoding

### DIFF
--- a/lib/protobuf/field/bytes_field.rb
+++ b/lib/protobuf/field/bytes_field.rb
@@ -18,8 +18,9 @@ module Protobuf
       end
 
       def decode(bytes)
-        bytes.force_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
-        bytes
+        bytes_to_decode = bytes.dup
+        bytes_to_decode.force_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
+        bytes_to_decode
       end
 
       def define_setter
@@ -46,11 +47,12 @@ module Protobuf
       end
 
       def encode(value)
-        value = value.encode if value.is_a?(::Protobuf::Message)
-        value.force_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
+        value_to_encode = value.dup
+        value_to_encode = value.encode if value.is_a?(::Protobuf::Message)
+        value_to_encode.force_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
 
-        string_size = ::Protobuf::Field::VarintField.encode(value.size)
-        string_size << value
+        string_size = ::Protobuf::Field::VarintField.encode(value_to_encode.size)
+        string_size << value_to_encode
       end
 
       def wire_type

--- a/lib/protobuf/field/string_field.rb
+++ b/lib/protobuf/field/string_field.rb
@@ -6,18 +6,19 @@ module Protobuf
       ENCODING = 'UTF-8'.freeze
 
       def decode(bytes)
-        bytes.force_encoding(::Protobuf::Field::StringField::ENCODING)
-        bytes
+        bytes_to_decode = bytes.dup
+        bytes_to_decode.force_encoding(::Protobuf::Field::StringField::ENCODING)
+        bytes_to_decode
       end
 
       # TODO: make replace character configurable?
       def encode(value)
-        value = value.dup if value.frozen?
-        value.encode!(::Protobuf::Field::StringField::ENCODING, :invalid => :replace, :undef => :replace, :replace => "")
-        value.force_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
+        value_to_encode = value.dup
+        value_to_encode.encode!(::Protobuf::Field::StringField::ENCODING, :invalid => :replace, :undef => :replace, :replace => "")
+        value_to_encode.force_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
 
-        string_size = ::Protobuf::Field::VarintField.encode(value.size)
-        string_size << value
+        string_size = ::Protobuf::Field::VarintField.encode(value_to_encode.size)
+        string_size << value_to_encode
       end
     end
   end

--- a/spec/lib/protobuf/field/string_field_spec.rb
+++ b/spec/lib/protobuf/field/string_field_spec.rb
@@ -1,6 +1,9 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 describe ::Protobuf::Field::StringField do
+
   describe '#encode' do
     context 'when a repeated string field contains frozen strings' do
       it 'does not raise an encoding error' do
@@ -19,5 +22,25 @@ describe ::Protobuf::Field::StringField do
         }.not_to raise_error
       end
     end
+
+    it 'does not alter string values after encoding multiple times' do
+      source_string = "foo"
+      proto = ::Test::Resource.new(:name => source_string)
+      proto.encode
+      proto.name.should eq source_string
+      proto.encode
+      proto.name.should eq source_string
+    end
+
+    it 'does not alter unicode string values after encoding multiple times' do
+      source_string = "¢"
+      proto = ::Test::Resource.new(:name => source_string)
+      proto.encode
+      proto.name.should eq source_string
+      proto.encode
+      proto.name.should eq source_string
+    end
   end
+
+
 end


### PR DESCRIPTION
I've got a StringField whose value contains unicode characters.

It seems that when the message is serialized to binary bytes and then deserialized to message, the unicode characters in the StringField is replaced with empty char "".

I found that in Protobuf::Field::StringFiled.encode(value) function, value's encoding is "ASCII-8BIT", but it should be UTF-8 actually. After calling value.encode!, because char in UTF-8 is not valid in ASCII-8BIT, these chars are replaced with char "".

I didn't find out when and where the value encoding is changed from UTF-8 to ASCII-8BIT.

I plan to comment out the encode! line to get rid of this temporarily.

Hope this will be resolved.

thanks!
