### PR TITLE
Prevent infinite loop when looking up services

### DIFF
--- a/lib/protobuf/rpc/connectors/zmq.rb
+++ b/lib/protobuf/rpc/connectors/zmq.rb
@@ -88,13 +88,10 @@ module Protobuf
         #
         def lookup_server_uri
           5.times do
-            listings = service_directory.all_listings_for(service)
-            if listings
-              listings.each do |listing|
-                host = listing.try(:address)
-                port = listing.try(:port)
-                return "tcp://#{host}:#{port}" if host_alive?(host)
-              end
+            service_directory.all_listings_for(service).each do |listing|
+              host = listing.try(:address)
+              port = listing.try(:port)
+              return "tcp://#{host}:#{port}" if host_alive?(host)
             end
 
             host = options[:host]

--- a/lib/protobuf/rpc/service_directory.rb
+++ b/lib/protobuf/rpc/service_directory.rb
@@ -86,10 +86,10 @@ module Protobuf
       end
 
       def all_listings_for(service)
-        if running?
-          if @listings_by_service.key?(service.to_s)
-            @listings_by_service[service.to_s].entries.shuffle
-          end
+        if running? && @listings_by_service.key?(service.to_s)
+          @listings_by_service[service.to_s].entries.shuffle
+        else
+          []
         end
       end
 

--- a/spec/lib/protobuf/rpc/connectors/zmq_spec.rb
+++ b/spec/lib/protobuf/rpc/connectors/zmq_spec.rb
@@ -45,7 +45,7 @@ describe ::Protobuf::Rpc::Connectors::Zmq do
       end
 
       it "defaults to the options" do
-        service_directory.stub(:all_listings_for).and_return(nil)
+        service_directory.stub(:all_listings_for).and_return([])
         subject.send(:lookup_server_uri).should eq "tcp://127.0.0.1:9400"
       end
     end
@@ -54,13 +54,13 @@ describe ::Protobuf::Rpc::Connectors::Zmq do
       let(:running?) { false }
 
       it "defaults to the options" do
-        service_directory.stub(:all_listings_for).and_return(nil)
+        service_directory.stub(:all_listings_for).and_return([])
         subject.send(:lookup_server_uri).should eq "tcp://127.0.0.1:9400"
       end
     end
 
     it "checks if the server is alive" do
-      service_directory.stub(:all_listings_for).and_return(nil)
+      service_directory.stub(:all_listings_for).and_return([])
       subject.should_receive(:host_alive?).with("127.0.0.1") { true }
       subject.send(:lookup_server_uri).should eq "tcp://127.0.0.1:9400"
     end

--- a/spec/lib/protobuf/rpc/service_directory_spec.rb
+++ b/spec/lib/protobuf/rpc/service_directory_spec.rb
@@ -155,11 +155,19 @@ describe ::Protobuf::Rpc::ServiceDirectory do
     end
 
     describe "#all_listings_for" do
-      it "returns all listings for a given service" do
-        send_beacon(:heartbeat, hello_server)
-        send_beacon(:heartbeat, combo_server)
+      context "when listings are present" do
+        it "returns all listings for a given service" do
+          send_beacon(:heartbeat, hello_server)
+          send_beacon(:heartbeat, combo_server)
 
-        subject.all_listings_for("HelloService").size.should eq(2)
+          subject.all_listings_for("HelloService").size.should eq(2)
+        end
+      end
+
+      context "when no listings are present" do
+        it "returns and empty array" do
+          subject.all_listings_for("HelloService").size.should eq(0)
+        end
       end
     end
 


### PR DESCRIPTION
Currently the service directory lookup has the potential to enter into an infinite loop if none of the servers in the listing are alive, and will only exit this loop if a server comes online.  This pull request prevents an infinite loop from occurring and will abort the request on the client side after 5 seconds if a host is not found.

We first check all listings in a random order.  If none are alive, we check the default server.  If that is not alive, we retry 5 times, with a 1 second interval.  Once we have tried for 5 seconds, we raise an error "Host not found".
