### PR TITLE
Add UTF-8 header to compiled protobuf files

### DIFF
--- a/lib/protobuf/generators/file_generator.rb
+++ b/lib/protobuf/generators/file_generator.rb
@@ -93,6 +93,7 @@ module Protobuf
       end
 
       def print_file_comment
+        puts "# encoding: UTF-8\n\n"
         puts "##"
         puts "# This file is auto-generated. DO NOT EDIT!"
         puts "#"

--- a/spec/support/test/defaults.pb.rb
+++ b/spec/support/test/defaults.pb.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 ##
 # This file is auto-generated. DO NOT EDIT!
 #

--- a/spec/support/test/enum.pb.rb
+++ b/spec/support/test/enum.pb.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 ##
 # This file is auto-generated. DO NOT EDIT!
 #

--- a/spec/support/test/extended.pb.rb
+++ b/spec/support/test/extended.pb.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 ##
 # This file is auto-generated. DO NOT EDIT!
 #

--- a/spec/support/test/google_unittest.pb.rb
+++ b/spec/support/test/google_unittest.pb.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# encoding: UTF-8
 
 ##
 # This file is auto-generated. DO NOT EDIT!

--- a/spec/support/test/google_unittest_import.pb.rb
+++ b/spec/support/test/google_unittest_import.pb.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 ##
 # This file is auto-generated. DO NOT EDIT!
 #

--- a/spec/support/test/google_unittest_import_public.pb.rb
+++ b/spec/support/test/google_unittest_import_public.pb.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 ##
 # This file is auto-generated. DO NOT EDIT!
 #

--- a/spec/support/test/multi_field_extensions.pb.rb
+++ b/spec/support/test/multi_field_extensions.pb.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 ##
 # This file is auto-generated. DO NOT EDIT!
 #

--- a/spec/support/test/resource.pb.rb
+++ b/spec/support/test/resource.pb.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 ##
 # This file is auto-generated. DO NOT EDIT!
 #


### PR DESCRIPTION
All the default strings in the compiled protobuf files should be interpreted as UTF-8.

---

RFC @abrandoned @localshred
