### PR TITLE
Introduce the concept of a middleware stack (WIP)

### DIFF
--- a/lib/protobuf/rpc/middleware.rb
+++ b/lib/protobuf/rpc/middleware.rb
@@ -1,0 +1,14 @@
+require 'middleware'
+
+require 'protobuf/rpc/middleware/runner'
+
+module Protobuf
+  module Rpc
+    def self.middleware
+      @middleware ||= ::Middleware::Builder.new(:runner_class => ::Protobuf::Rpc::Middleware::Runner)
+    end
+
+    # Ensure the middleware stack is initialized
+    middleware
+  end
+end

--- a/lib/protobuf/rpc/middleware/runner.rb
+++ b/lib/protobuf/rpc/middleware/runner.rb
@@ -1,0 +1,18 @@
+require 'middleware/runner'
+
+module Protobuf
+  module Rpc
+    module Middleware
+      class Runner < ::Middleware::Runner
+        # Override the default middleware runner so we can ensure that the
+        # service dispatcher is the last thing called in the stack.
+        #
+        def initialize(stack)
+          stack << Protobuf::Rpc::ServiceDispatcher
+
+          super(stack)
+        end
+      end
+    end
+  end
+end

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -20,6 +20,7 @@ require "protobuf/version"
   s.require_paths = ["lib"]
 
   s.add_dependency 'activesupport'
+  s.add_dependency 'middleware'
   s.add_dependency 'multi_json'
   s.add_dependency 'thor'
 
@@ -31,5 +32,4 @@ require "protobuf/version"
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'timecop'
-  # s.add_development_dependency 'perftools.rb'
 end


### PR DESCRIPTION
In order to make PB more extensible, this introduces the concept of a middleware stack. It is invoked from the server and terminates at the dispatcher. The dispatcher returns an error or response proto which is then added to the response wrapper accordingly.
### WIP

This is a work in progress and as such doesn't have specs yet. I wanted to get a rough cut at how this will work and where it will hook into the hand-off from the server to the service dispatcher.

I tried to keep this as focused as possible, adding some notes for future enhancements as I saw them. The main problem I had was that the server module is dependent on instance variables that it sets and that are setup by other modules/classes. Ideally, we could move some of the request/response parsing code into the middleware stack, but the current architecture makes that difficult. I think there are a couple of things that could easily be moved into middleware (logging, stats), but I think another cut is necessary for that to happen.
### API

As far as I know, we're planning on extracting all of the servers into their own gems, so that may be an opportunity to further solidify the API making a clearer cut between what the server does and what the dispatcher does (and possibly even breaking up the dispatcher a bit).

// @abrandoned @localshred @devin-c
