### PR TITLE
Introduce the concept of a middleware stack

### DIFF
--- a/lib/protobuf/rpc/middleware.rb
+++ b/lib/protobuf/rpc/middleware.rb
@@ -1,0 +1,14 @@
+require 'middleware'
+
+require 'protobuf/rpc/middleware/runner'
+
+module Protobuf
+  module Rpc
+    def self.middleware
+      @middleware ||= ::Middleware::Builder.new(:runner_class => ::Protobuf::Rpc::Middleware::Runner)
+    end
+
+    # Ensure the middleware stack is initialized
+    middleware
+  end
+end

--- a/lib/protobuf/rpc/middleware/runner.rb
+++ b/lib/protobuf/rpc/middleware/runner.rb
@@ -1,0 +1,18 @@
+require 'middleware/runner'
+
+module Protobuf
+  module Rpc
+    module Middleware
+      class Runner < ::Middleware::Runner
+        # Override the default middleware runner so we can ensure that the
+        # service dispatcher is the last thing called in the stack.
+        #
+        def initialize(stack)
+          stack << Protobuf::Rpc::ServiceDispatcher
+
+          super(stack)
+        end
+      end
+    end
+  end
+end

--- a/lib/protobuf/rpc/server.rb
+++ b/lib/protobuf/rpc/server.rb
@@ -3,6 +3,7 @@ require 'protobuf/logger'
 require 'protobuf/rpc/rpc.pb'
 require 'protobuf/rpc/buffer'
 require 'protobuf/rpc/error'
+require 'protobuf/rpc/middleware'
 require 'protobuf/rpc/stat'
 require 'protobuf/rpc/service_dispatcher'
 
@@ -22,22 +23,29 @@ module Protobuf
       def handle_request(request_data)
         log_debug { sign_message("Handling request") }
 
-        initialize_stats!
-        stats.request_size = request_data.size
+        # Create an env object that holds different parts of the environment and
+        # is available to all of the middlewares.
+        initialize_env!
+        env['stats'].request_size = request_data.size
 
-        request = decode_request_data(request_data)
-        stats.client = request.caller
+        env['request'] = decode_request_data(request_data)
+        env['stats'].client = env['request'].caller
 
-        response_data = dispatch_request(request)
+        # Invoke the middleware stack, the last of which is the service
+        # dispatcher. The dispatcher sets either an error object or a
+        # protobuf response object to env['response'].
+        env = Rpc.middleware.call(env)
+
+        response_data = handle_response(env['response'])
       rescue => error
         log_exception(error)
         response_data = handle_error(error)
       ensure
         encoded_response = encode_response_data(response_data)
-        stats.stop
+        env['stats'].stop
 
         # Log the response stats
-        log_info { stats.to_s }
+        log_info { env['stats'].to_s }
 
         encoded_response
       end
@@ -60,24 +68,6 @@ module Protobuf
         raise exception
       end
 
-      # Dispatch the request to the service
-      #
-      def dispatch_request(request)
-        dispatcher = ServiceDispatcher.new(request)
-        stats.dispatcher = dispatcher
-
-        # Log the request stats
-        log_info { stats.to_s }
-
-        dispatcher.invoke!
-
-        if dispatcher.success?
-          Socketrpc::Response.new(:response_proto => response_data)
-        else
-          handle_error(dispatcher.error)
-        end
-      end
-
       # Encode the response wrapper to return to the client
       #
       def encode_response_data(response)
@@ -88,7 +78,7 @@ module Protobuf
         log_exception(error)
         encoded_response = handle_error(error).encode
       ensure
-        stats.response_size = encoded_response.size
+        env['stats'].response_size = encoded_response.size
         encoded_response
       end
 
@@ -104,13 +94,30 @@ module Protobuf
         end
       end
 
-      # Initialize a new stats tracker
+      # The middleware stack returns either an error or response proto. Package
+      # it up so that it's in the correct spot in the respone wrapper
+      #
+      def handle_response(response)
+        if response < Protobuf::Rpc::PbError
+          handle_error(response)
+        else
+          Socketrpc::Response.new(:response_proto => response)
+        end
+      end
+
+      # Initialize a new environment object
       #
       # NOTE: This has to be reinitialized with each request and can't be
-      # memoized since servers aren't reinitialized with each request
+      # memoized since servers aren't always reinitialized with each request
       #
-      def initialize_stats!
-        @_stats = Stat.new(:SERVER)
+      def initialize_env!
+        # TODO: Add extra info about the environment (i.e. variables) and other
+        # information that might be useful
+        @_env = {
+          'request' => nil,
+          'response' => nil,
+          'stats' => Stat.new(:SERVER)
+        }
       end
 
       def stats

--- a/lib/protobuf/rpc/service_dispatcher.rb
+++ b/lib/protobuf/rpc/service_dispatcher.rb
@@ -3,19 +3,30 @@ require 'protobuf/logger'
 module Protobuf
   module Rpc
     class ServiceDispatcher
-
       include ::Protobuf::Logger::LogMethods
 
       attr_accessor :service, :service_klass, :callable_method, :outer_request
       attr_accessor :definition, :response, :error
 
-      def initialize(wrapper_request)
-        self.error = nil
-        self.outer_request = wrapper_request
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        self.outer_request = env['request']
+
+        env['stats'].dispatcher = self
 
         init_service
         init_method if service_klass.present?
         register_rpc_failed if service.present?
+
+        # Log the request stats
+        log_info { env['stats'].to_s }
+
+        invoke!
+
+        env
       end
 
       # Call the given service method. If we get to this point and an error
@@ -27,7 +38,7 @@ module Protobuf
           validate_response
         end
 
-        return error || response
+        env['response'] = error || response
       end
 
       # We're successful if the error is not populated.

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -20,6 +20,7 @@ require "protobuf/version"
   s.require_paths = ["lib"]
 
   s.add_dependency 'activesupport'
+  s.add_dependency 'middleware'
   s.add_dependency 'multi_json'
   s.add_dependency 'thor'
 
@@ -31,5 +32,4 @@ require "protobuf/version"
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'timecop'
-  # s.add_development_dependency 'perftools.rb'
 end


### PR DESCRIPTION
In order to make PB more extensible, this introduces the concept of a middleware stack. Building off of #144, the middleware stack is invoked from the server and terminates at the dispatcher.

Add an env object used to pass stuff to/from the middleware:
- Use it in the dispatcher store the response and return it instead
- Use it in the server module to access stats, set the request, and
  process the response

// @localshred @abrandoned @brianstien @devin-c
