### PR TITLE
add backwards compat for busy and Thread

### DIFF
--- a/lib/protobuf/rpc/servers/zmq/server.rb
+++ b/lib/protobuf/rpc/servers/zmq/server.rb
@@ -3,6 +3,7 @@ require 'protobuf/rpc/servers/zmq/worker'
 require 'protobuf/rpc/servers/zmq/broker'
 require 'protobuf/rpc/dynamic_discovery.pb'
 require 'securerandom'
+require 'thread'
 
 module Protobuf
   module Rpc
@@ -37,7 +38,7 @@ module Protobuf
         end
 
         def all_workers_busy?
-          workers.all? { |thread| !!thread.thread_variable_get(:busy) }
+          workers.all? { |thread| !!thread[:busy] }
         end
 
         def backend_port
@@ -111,7 +112,7 @@ module Protobuf
         end
 
         def busy_worker_count
-          workers.count { |thread| !!thread.thread_variable_get(:busy) }
+          workers.count { |thread| !!thread[:busy] }
         end
 
         def frontend_ip

--- a/lib/protobuf/rpc/servers/zmq/worker.rb
+++ b/lib/protobuf/rpc/servers/zmq/worker.rb
@@ -1,5 +1,6 @@
 require 'protobuf/rpc/server'
 require 'protobuf/rpc/servers/zmq/util'
+require 'thread'
 
 module Protobuf
   module Rpc
@@ -51,10 +52,10 @@ module Protobuf
             break if rc == -1
 
             if rc > 0
-              ::Thread.current.thread_variable_set(:busy, true)
+              ::Thread.current[:busy] = true
               initialize_request!
               process_request
-              ::Thread.current.thread_variable_set(:busy, false)
+              ::Thread.current[:busy] = false
             end
           end
         ensure


### PR DESCRIPTION
thread_variable_get/set are not avail to rubies pre 2, so this makes these settings work with pre-2 rubies (which I believe is desired)

@localshred 
