### PR TITLE
Extract exception handling into a middleware

### DIFF
--- a/lib/protobuf/rpc/middleware.rb
+++ b/lib/protobuf/rpc/middleware.rb
@@ -1,5 +1,6 @@
 require 'middleware'
 
+require 'protobuf/rpc/middleware/exception_handler'
 require 'protobuf/rpc/middleware/request_decoder'
 require 'protobuf/rpc/middleware/response_encoder'
 require 'protobuf/rpc/middleware/runner'
@@ -16,4 +17,5 @@ module Protobuf
 
   Rpc.middleware.use(Rpc::Middleware::RequestDecoder)
   Rpc.middleware.use(Rpc::Middleware::ResponseEncoder)
+  Rpc.middleware.use(Rpc::Middleware::ExceptionHandler)
 end

--- a/lib/protobuf/rpc/middleware/exception_handler.rb
+++ b/lib/protobuf/rpc/middleware/exception_handler.rb
@@ -1,0 +1,35 @@
+module Protobuf
+  module Rpc
+    module Middleware
+      class ExceptionHandler
+        include Logger::LogMethods
+
+        attr_reader :app
+
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          app.call(env)
+        rescue => exception
+          log_exception(exception)
+
+          # Rescue exceptions, re-wrap them as generic Protobuf errors,
+          # and set the response
+          env.response = wrap_exception(exception)
+          env
+        end
+
+      private
+
+        # Wrap exceptions in a generic Protobuf errors unless they already are
+        #
+        def wrap_exception(exception)
+          exception = PbError.new(exception.message) unless exception.is_a?(PbError)
+          exception
+        end
+      end
+    end
+  end
+end

--- a/lib/protobuf/rpc/server.rb
+++ b/lib/protobuf/rpc/server.rb
@@ -36,11 +36,6 @@ module Protobuf
         log_info { env.stats.to_s }
 
         env.encoded_response
-      rescue => exception
-        log_exception(exception)
-
-        response = PbError.new(exception.message).to_response
-        response.encode
       end
 
       def log_signature
@@ -57,9 +52,9 @@ module Protobuf
       def initialize_env!(request_data)
         # TODO: Figure out a better way to handle logging with signatures
         @_env = Env.new(
-         'encoded_request' => request_data,
-         'log_signature' => log_signature,
-         'stats' => Stat.new(:SERVER)
+          'encoded_request' => request_data,
+          'log_signature' => log_signature,
+          'stats' => Stat.new(:SERVER)
         )
       end
     end

--- a/spec/lib/protobuf/rpc/middleware/exception_handler_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/exception_handler_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Protobuf::Rpc::Middleware::ExceptionHandler do
+  let(:app) { Proc.new { |env| env } }
+  let(:env) { Protobuf::Rpc::Env.new }
+
+  subject { described_class.new(app) }
+
+  describe "#call" do
+    it "calls the stack" do
+      app.should_receive(:call).with(env)
+      subject.call(env)
+    end
+
+    it "returns the env" do
+      subject.call(env).should eq env
+    end
+
+    context "when exceptions occur" do
+      let(:error) { Protobuf::Rpc::MethodNotFound.new('Boom!') }
+
+      before { app.stub(:call).and_raise(error, 'Boom!') }
+
+      it "rescues exceptions" do
+        expect { subject.call(env) }.not_to raise_exception
+      end
+
+      context "when exception is a Protobuf error" do
+        let(:error) { Protobuf::Rpc::MethodNotFound.new('Boom!') }
+
+        before { app.stub(:call).and_raise(error) }
+
+        it "does not wrap the exception in a generic Protobuf error" do
+          stack_env = subject.call(env)
+          stack_env.response.should eq error
+        end
+      end
+
+      context "when exception is not a Protobuf error" do
+        let(:error) { Protobuf::Rpc::PbError.new('Boom!') }
+
+        before { app.stub(:call).and_raise(RuntimeError, 'Boom!') }
+
+        it "wraps the exception in a generic Protobuf error" do
+          stack_env = subject.call(env)
+          stack_env.response.should eq error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rescue exceptions that are raised and set the response. If the exception rescued is not a Protobuf error, it is wrapped in a generic Protobuf error.

// @localshred @abrandoned 
