### PR TITLE
Extract logging and stats into a middleware

### DIFF
--- a/lib/protobuf/rpc/env.rb
+++ b/lib/protobuf/rpc/env.rb
@@ -24,6 +24,10 @@ module Protobuf
             def #{name}=(value)
               self['#{name}'] = value
             end
+
+            def #{name}?
+              ! self['#{name}'].nil?
+            end
           METHOD
         end
       end
@@ -38,10 +42,12 @@ module Protobuf
                     :request,
                     :response,
                     :service_name,
-                    :stats
+                    :worker_id
 
-      def initialize(env = {})
-        merge!(env)
+      def initialize(options={})
+        merge!(options)
+
+        self['worker_id'] = ::Thread.current.object_id.to_s(16)
       end
     end
   end

--- a/lib/protobuf/rpc/middleware.rb
+++ b/lib/protobuf/rpc/middleware.rb
@@ -1,6 +1,7 @@
 require 'middleware'
 
 require 'protobuf/rpc/middleware/exception_handler'
+require 'protobuf/rpc/middleware/logger'
 require 'protobuf/rpc/middleware/request_decoder'
 require 'protobuf/rpc/middleware/response_encoder'
 require 'protobuf/rpc/middleware/runner'
@@ -16,6 +17,7 @@ module Protobuf
   end
 
   Rpc.middleware.use(Rpc::Middleware::RequestDecoder)
+  Rpc.middleware.use(Rpc::Middleware::Logger)
   Rpc.middleware.use(Rpc::Middleware::ResponseEncoder)
   Rpc.middleware.use(Rpc::Middleware::ExceptionHandler)
 end

--- a/lib/protobuf/rpc/middleware/exception_handler.rb
+++ b/lib/protobuf/rpc/middleware/exception_handler.rb
@@ -2,7 +2,7 @@ module Protobuf
   module Rpc
     module Middleware
       class ExceptionHandler
-        include Logger::LogMethods
+        include ::Protobuf::Logger::LogMethods
 
         attr_reader :app
 

--- a/lib/protobuf/rpc/middleware/logger.rb
+++ b/lib/protobuf/rpc/middleware/logger.rb
@@ -1,0 +1,91 @@
+module Protobuf
+  module Rpc
+    module Middleware
+      class Logger
+        def initialize(app)
+          @app = app
+        end
+
+        # TODO: Figure out how to control when logs are flushed
+        def call(env)
+          instrumenter.start
+          instrumenter.flush(env) # Log request stats
+
+          env = @app.call(env)
+
+          instrumenter.stop
+          instrumenter.flush(env) # Log response stats
+
+          env
+        end
+
+      private
+
+        def instrumenter
+          @instrumenter ||= Instrumenter.new
+        end
+
+        # TODO: Replace this with ActiveSupport::Notifications and log subscribers
+        # TODO: Consider adopting Rails-style logging so we can track serialization
+        # time as well as ActiveRecord time, etc.:
+        #
+        #     Started GET "/" for 127.0.0.1 at 2014-02-12 09:40:29 -0700
+        #     Processing by ReleasesController#index as HTML
+        #       Rendered releases/_release.html.erb (0.0ms)
+        #       Rendered releases/_release.html.erb (0.0ms)
+        #       Rendered releases/_release.html.erb (0.0ms)
+        #       Rendered releases/_release.html.erb (0.0ms)
+        #       Rendered releases/index.html.erb within layouts/application (11.0ms)
+        #     Completed 200 OK in 142ms (Views: 117.6ms | ActiveRecord: 1.7ms)
+        #
+        class Instrumenter
+          attr_reader :env
+
+          def flush(env)
+            Protobuf::Logger.info { to_s(env) }
+          end
+
+          def start
+            @start_time = ::Time.now.utc
+          end
+
+          def stop
+            @end_time = ::Time.now.utc
+          end
+
+          def to_s(env)
+            @env = env
+
+            [
+              "[SRV]",
+              env.caller,
+              env.worker_id,
+              rpc,
+              sizes,
+              elapsed_time,
+              @end_time.try(:iso8601)
+            ].compact.join(' - ')
+          end
+
+        private
+
+          def elapsed_time
+            (@start_time && @end_time ? "#{(@end_time - @start_time).round(4)}s" : nil)
+          end
+
+          def rpc
+            env.service_name && env.method_name ? "#{env.service_name}##{env.method_name}" : nil
+          end
+
+          def sizes
+            if env.encoded_response?
+              "#{env.encoded_request.size}B/#{env.encoded_response.size}B"
+            else
+              "#{env.encoded_request.size}B/-"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/protobuf/rpc/middleware/request_decoder.rb
+++ b/lib/protobuf/rpc/middleware/request_decoder.rb
@@ -2,7 +2,7 @@ module Protobuf
   module Rpc
     module Middleware
       class RequestDecoder
-        include Logger::LogMethods
+        include ::Protobuf::Logger::LogMethods
 
         attr_reader :app, :env
 
@@ -27,10 +27,6 @@ module Protobuf
             env.caller = env.request.caller
             env.service_name = env.request.service_name
             env.method_name = env.request.method_name
-
-            # TODO: Figure out a better way to do stat tracking
-            env.stats.request_size = env.encoded_request.size
-            env.stats.client = env.request.caller
 
             app.call(env)
           else

--- a/lib/protobuf/rpc/middleware/response_encoder.rb
+++ b/lib/protobuf/rpc/middleware/response_encoder.rb
@@ -2,7 +2,7 @@ module Protobuf
   module Rpc
     module Middleware
       class ResponseEncoder
-        include Logger::LogMethods
+        include ::Protobuf::Logger::LogMethods
 
         attr_reader :app, :env
 
@@ -12,11 +12,7 @@ module Protobuf
 
         def call(env)
           @env = app.call(env)
-
           @env.encoded_response = encode_response_data(@env.response)
-
-          # TODO: Extract this when stats are moved to a middleware
-          @env.stats.response_size = @env.encoded_response.size
 
           @env
         end

--- a/lib/protobuf/rpc/server.rb
+++ b/lib/protobuf/rpc/server.rb
@@ -5,7 +5,6 @@ require 'protobuf/rpc/buffer'
 require 'protobuf/rpc/env'
 require 'protobuf/rpc/error'
 require 'protobuf/rpc/middleware'
-require 'protobuf/rpc/stat'
 require 'protobuf/rpc/service_dispatcher'
 
 module Protobuf
@@ -22,40 +21,18 @@ module Protobuf
       # Invoke the service method dictated by the proto wrapper request object
       #
       def handle_request(request_data)
-        log_debug { sign_message("Handling request") }
-
         # Create an env object that holds different parts of the environment and
         # is available to all of the middlewares
-        initialize_env!(request_data)
+        env = Env.new('encoded_request' => request_data, 'log_signature' => log_signature)
 
         # Invoke the middleware stack, the last of which is the service dispatcher
         env = Rpc.middleware.call(env)
-        env.stats.stop
-
-        # Log the response stats
-        log_info { env.stats.to_s }
 
         env.encoded_response
       end
 
       def log_signature
         @_log_signature ||= "[server-#{self.class.name}]"
-      end
-
-    private
-
-      # Initialize a new environment object
-      #
-      # NOTE: This has to be reinitialized with each request and can't be
-      # memoized since servers aren't always reinitialized with each request
-      #
-      def initialize_env!(request_data)
-        # TODO: Figure out a better way to handle logging with signatures
-        @_env = Env.new(
-          'encoded_request' => request_data,
-          'log_signature' => log_signature,
-          'stats' => Stat.new(:SERVER)
-        )
       end
     end
   end

--- a/spec/lib/protobuf/rpc/middleware/logger_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/logger_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Protobuf::Rpc::Middleware::Logger do
+  let(:app) { Proc.new { |env| env } }
+  let(:env) { Protobuf::Rpc::Env.new }
+
+  subject { described_class.new(app) }
+
+  describe "#call" do
+    it "calls the stack" do
+      app.should_receive(:call).with(env)
+      subject.call(env)
+    end
+
+    it "returns the env" do
+      subject.call(env).should eq env
+    end
+  end
+end

--- a/spec/lib/protobuf/rpc/middleware/request_decoder_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/request_decoder_spec.rb
@@ -6,8 +6,7 @@ describe Protobuf::Rpc::Middleware::RequestDecoder do
   let(:env) {
     Protobuf::Rpc::Env.new(
       'encoded_request' => encoded_request,
-      'log_signature' => 'log_signature',
-      'stats' => Protobuf::Rpc::Stat.new(:SERVER)
+      'log_signature' => 'log_signature'
     )
   }
   let(:encoded_request) { request.encode }
@@ -47,16 +46,6 @@ describe Protobuf::Rpc::Middleware::RequestDecoder do
     it "sets Env#method_name" do
       stack_env = subject.call(env)
       stack_env.method_name.should eq method_name
-    end
-
-    it "sets Env#stats.request_size" do
-      stack_env = subject.call(env)
-      stack_env.stats.request_size.should eq encoded_request.size
-    end
-
-    it "sets Env#stats.client" do
-      stack_env = subject.call(env)
-      stack_env.stats.client.should eq caller
     end
 
     context "when decoding fails" do

--- a/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
@@ -5,8 +5,7 @@ describe Protobuf::Rpc::Middleware::ResponseEncoder do
   let(:env) {
     Protobuf::Rpc::Env.new(
       'response' => response_proto,
-      'log_signature' => 'log_signature',
-      'stats' => Protobuf::Rpc::Stat.new(:SERVER)
+      'log_signature' => 'log_signature'
     )
   }
   let(:encoded_response) { response.encode }
@@ -30,18 +29,12 @@ describe Protobuf::Rpc::Middleware::ResponseEncoder do
       subject.call(env)
     end
 
-    it "sets Env#stats.request_size" do
-      stack_env = subject.call(env)
-      stack_env.stats.response_size.should eq encoded_response.size
-    end
-
     context "when response is a Protobuf error" do
       let(:encoded_response) { response.encode }
       let(:env) {
         Protobuf::Rpc::Env.new(
           'response' => error,
-          'log_signature' => 'log_signature',
-          'stats' => Protobuf::Rpc::Stat.new(:SERVER)
+          'log_signature' => 'log_signature'
         )
       }
       let(:error) { Protobuf::Rpc::RpcError.new }


### PR DESCRIPTION
Instead of capturing stats all over the place, rely on the env object and middleware placement (between the decoder and encoder) to capture everything we need to log requests and responses.

The embedded instrumenter is a stop-gap until we can get things switched over to use Active Support's notifications to track and log.
