### PR TITLE
Reorder middleware so exception handler is first

### DIFF
--- a/lib/protobuf/rpc/error.rb
+++ b/lib/protobuf/rpc/error.rb
@@ -13,6 +13,10 @@ module Protobuf
         super message
       end
 
+      def encode
+        to_response.encode
+      end
+
       def to_response
         Socketrpc::Response.new(:error => message, :error_reason => error_type)
       end

--- a/lib/protobuf/rpc/middleware.rb
+++ b/lib/protobuf/rpc/middleware.rb
@@ -16,8 +16,8 @@ module Protobuf
     middleware
   end
 
+  Rpc.middleware.use(Rpc::Middleware::ExceptionHandler)
   Rpc.middleware.use(Rpc::Middleware::RequestDecoder)
   Rpc.middleware.use(Rpc::Middleware::Logger)
   Rpc.middleware.use(Rpc::Middleware::ResponseEncoder)
-  Rpc.middleware.use(Rpc::Middleware::ExceptionHandler)
 end

--- a/lib/protobuf/rpc/middleware/exception_handler.rb
+++ b/lib/protobuf/rpc/middleware/exception_handler.rb
@@ -16,8 +16,9 @@ module Protobuf
           log_exception(exception)
 
           # Rescue exceptions, re-wrap them as generic Protobuf errors,
-          # and set the response
+          # and encode them
           env.response = wrap_exception(exception)
+          env.encoded_response = env.response.encode
           env
         end
 

--- a/lib/protobuf/rpc/middleware/response_encoder.rb
+++ b/lib/protobuf/rpc/middleware/response_encoder.rb
@@ -11,10 +11,12 @@ module Protobuf
         end
 
         def call(env)
-          @env = app.call(env)
-          @env.encoded_response = encode_response_data(@env.response)
+          @env = env
 
-          @env
+          env = app.call(env)
+          env.encoded_response = encode_response_data(env.response)
+
+          env
         end
 
         def log_signature
@@ -34,13 +36,8 @@ module Protobuf
           log_exception(exception)
 
           # Rescue encoding exceptions, re-wrap them as generic protobuf errors,
-          # and set it as the encoded response so we always have something to
-          # send back
-          error = PbError.new(exception.message)
-          env.response = error
-          env.encoded_response = error.to_response.encode
-        ensure
-          return env.encoded_response
+          # and re-raise them
+          raise PbError.new(exception.message)
         end
 
         # The middleware stack returns either an error or response proto. Package

--- a/spec/lib/protobuf/rpc/middleware/request_decoder_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/request_decoder_spec.rb
@@ -49,19 +49,10 @@ describe Protobuf::Rpc::Middleware::RequestDecoder do
     end
 
     context "when decoding fails" do
-      let(:error) { Protobuf::Rpc::BadRequestData.new("Unable to decode request: Boom!") }
-      let(:response) { error.to_response }
+      before { Protobuf::Socketrpc::Request.stub(:decode).and_raise(RuntimeError) }
 
-      before { Protobuf::Socketrpc::Request.stub(:decode).and_raise(RuntimeError, 'Boom!') }
-
-      it "does not call the stack" do
-        app.should_not_receive(:call)
-        subject.call(env)
-      end
-
-      it "sets Env#response" do
-        stack_env = subject.call(env)
-        stack_env.response.should eq error
+      it "raises a bad request data exception" do
+        expect { subject.call(env) }.to raise_exception(Protobuf::Rpc::BadRequestData)
       end
     end
   end

--- a/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
@@ -47,19 +47,10 @@ describe Protobuf::Rpc::Middleware::ResponseEncoder do
     end
 
     context "when encoding fails" do
-      let(:error) { Protobuf::Rpc::PbError.new('Boom!') }
-      let(:response) { error.to_response }
+      before { Protobuf::Socketrpc::Response.stub(:encode).and_raise(RuntimeError) }
 
-      before { Protobuf::Socketrpc::Response.stub(:encode).and_raise(RuntimeError, 'Boom!') }
-
-      it "sets Env#response" do
-        stack_env = subject.call(env)
-        stack_env.response.should eq error
-      end
-
-      it "encodes the response" do
-        stack_env = subject.call(env)
-        stack_env.encoded_response.should eq encoded_response
+      it "raises a bad request data exception" do
+        expect { subject.call(env) }.to raise_exception(Protobuf::Rpc::PbError)
       end
     end
   end


### PR DESCRIPTION
Making the exception handler the first middleware ensures that all exceptions are rescued. It also greatly simplifies the other middleware since exceptions can simply be raised instead of returned in `env.response` and exceptions don't need to be encoded.

In the process, I was able to clean up the service dispatcher since it can now safely raise exceptions instead of sending them all back in the response object.

// @localshred @abrandoned 
