### PR TITLE
Decode everything in the request decoder

### DIFF
--- a/lib/protobuf/rpc/env.rb
+++ b/lib/protobuf/rpc/env.rb
@@ -40,7 +40,11 @@ module Protobuf
                     :log_signature,
                     :method_name,
                     :request,
+                    :request_type,
                     :response,
+                    :response_type,
+                    :rpc_method,
+                    :rpc_service,
                     :service_name,
                     :worker_id
 

--- a/lib/protobuf/rpc/service_dispatcher.rb
+++ b/lib/protobuf/rpc/service_dispatcher.rb
@@ -5,7 +5,7 @@ module Protobuf
     class ServiceDispatcher
       include ::Protobuf::Logger::LogMethods
 
-      attr_accessor :callable_method, :definition, :env, :error, :response, :service, :service_klass
+      attr_reader :env
 
       def initialize(app)
         # End of the line...
@@ -14,48 +14,32 @@ module Protobuf
       def call(env)
         @env = env
 
-        init_service!
-        init_method!
         register_rpc_failed
-        invoke!
 
-        self.env
+        env.response = dispatch_rpc_request
+        env
       end
 
-      # We're in error if the error is populated.
-      #
-      def error?
-        ! success?
-      end
-
-      # Call the given service method. If we get to this point and an error
-      # has already occurred, do not invoke the method and simply respond.
-      #
-      def invoke!
-        unless error?
-          callable_method.call
-          validate_response
-        end
-
-        env.response = error || response
-      end
-
-      def outer_request
-        env.request
-      end
-
-      # We're successful if the error is not populated.
-      #
-      def success?
-        error.nil?
+      def rpc_service
+        @rpc_service ||= env.rpc_service.new(env)
       end
 
     private
 
+      # Get a callable RPC method for the current request.
+      #
+      def callable_rpc_method
+        unless rpc_service.respond_to?(method_name)
+          raise MethodNotFound.new("#{rpc_service.class.name}##{method_name} is not implemented.")
+        end
+
+        rpc_service.callable_rpc_method(method_name)
+      end
+
       # Prod the object to see if we can produce a proto object as a response
       # candidate. Either way, return the candidate for validation.
       def coerced_response
-        candidate = service.response
+        candidate = rpc_service.response
 
         case
         when candidate.is_a?(::Protobuf::Message) then
@@ -63,71 +47,55 @@ module Protobuf
         when candidate.respond_to?(:to_proto) then
           candidate = candidate.to_proto
         when candidate.respond_to?(:to_proto_hash) then
-          candidate = definition.response_type.new(candidate.to_proto_hash)
+          candidate = env.response_type.new(candidate.to_proto_hash)
         when candidate.respond_to?(:to_hash) then
-          candidate = definition.response_type.new(candidate.to_hash)
+          candidate = env.response_type.new(candidate.to_hash)
         end
 
         candidate
       end
 
-      # Get the method for the current request.
-      #
-      def init_method!
-        method_name = outer_request.method_name.underscore.to_sym
-        request_proto = outer_request.has_field?(:request_proto) ? outer_request.request_proto : nil
-
-        self.service = service_klass.new(method_name, request_proto, outer_request.caller)
-
-        unless service_klass.rpc_method?(method_name)
-          raise MethodNotFound, "#{service.class.name}##{method_name} is not a defined rpc method."
-        end
-
-        unless self.service.respond_to?(method_name)
-          raise MethodNotFound, "#{service.class.name}##{method_name} is not implemented."
-        end
-
-        self.callable_method = service.callable_rpc_method(method_name)
-        self.definition = service.rpcs[method_name]
+      def dispatch_rpc_request
+        # Call the given service method.
+        callable_rpc_method.call
+        validate_response!
       end
 
-      # Constantize the service for this request. Initialization of the service
-      # happens when we verify that the method is callable for this service.
-      #
-      def init_service!
-        self.service_klass = outer_request.service_name.constantize
-      rescue NameError
-        raise ServiceNotFound, "Service class #{outer_request.service_name} is not defined."
+      def method_name
+        env.method_name
       end
 
       # Make sure we get rpc errors back.
       #
       def register_rpc_failed
-        service.on_rpc_failed(method(:rpc_failed_callback))
+        rpc_service.on_rpc_failed(method(:rpc_failed_callback))
       end
 
       # Receive the failure message from the service. This method is registered
       # as the callable to the service when an `rpc_failed` call is invoked.
       #
       def rpc_failed_callback(message)
-        self.error = RpcFailed.new(message.respond_to?(:message) ? message.message : message)
+        message = message.message if message.respond_to?(:message)
+        raise RpcFailed.new(message)
+      end
 
-        log_error { sign_message("RPC Failed: #{error.message}") }
+      def rpc_method
+        env.rpc_method
       end
 
       # Ensure that the response candidate we've been given is of the type
       # we expect so that deserialization on the client side works.
       #
-      def validate_response
+      def validate_response!
         candidate = coerced_response
-        expected = definition.response_type
         actual = candidate.class
+        expected = env.response_type
 
         if expected != actual
-          raise BadResponseProto, "Response proto changed from #{expected.name} to #{actual.name}"
+          raise BadResponseProto.new("Response proto changed from #{expected.name} to #{actual.name}")
         end
 
-        self.response = candidate
+        candidate
       end
     end
   end

--- a/spec/lib/protobuf/rpc/service_spec.rb
+++ b/spec/lib/protobuf/rpc/service_spec.rb
@@ -120,18 +120,19 @@ describe Protobuf::Rpc::Service do
         end
       end
 
-
-      let(:request) do
-        Test::ResourceFindRequest.new(:name => 'resource')
-      end
-
-      let(:response) do
-        Test::Resource.new
-      end
+      let(:request) { Test::ResourceFindRequest.new(:name => 'resource') }
+      let(:response) { Test::Resource.new }
 
       context 'when calling the rpc method' do
         context 'when response is implied' do
-          subject { NewTestService.new(:find_with_implied_response, request.encode) }
+          let(:env) {
+            Protobuf::Rpc::Env.new(
+              'method_name' => :find_with_implied_response,
+              'request' => request
+            )
+          }
+
+          subject { NewTestService.new(env) }
 
           before { subject.find_with_implied_response }
           its(:response) { should be_a(Test::Resource) }
@@ -139,7 +140,14 @@ describe Protobuf::Rpc::Service do
         end
 
         context 'when using respond_with paradigm' do
-          subject { NewTestService.new(:find_with_respond_with, request.encode) }
+          let(:env) {
+            Protobuf::Rpc::Env.new(
+              'method_name' => :find_with_respond_with,
+              'request' => request
+            )
+          }
+
+          subject { NewTestService.new(env) }
 
           before { subject.find_with_respond_with }
           its(:response) { should be_a(Test::Resource) }
@@ -148,7 +156,14 @@ describe Protobuf::Rpc::Service do
       end
 
       context 'when calling rpc_failed in the method' do
-        subject { NewTestService.new(:find_with_rpc_failed, request.encode) }
+        let(:env) {
+          Protobuf::Rpc::Env.new(
+            'method_name' => :find_with_rpc_failed,
+            'request' => request
+          )
+        }
+
+        subject { NewTestService.new(env) }
 
         it 'invokes the rpc_failed callback with the error' do
           error = nil
@@ -159,7 +174,5 @@ describe Protobuf::Rpc::Service do
         end
       end
     end
-
   end
-
 end

--- a/spec/support/test/resource.pb.rb
+++ b/spec/support/test/resource.pb.rb
@@ -103,6 +103,7 @@ module Test
   #
   class ResourceService < ::Protobuf::Rpc::Service
     rpc :find, ::Test::ResourceFindRequest, ::Test::Resource
+    rpc :find_with_rpc_failed, ::Test::ResourceFindRequest, ::Test::Resource
     rpc :find_with_sleep, ::Test::ResourceSleepRequest, ::Test::Resource
   end
 

--- a/spec/support/test/resource.proto
+++ b/spec/support/test/resource.proto
@@ -84,5 +84,6 @@ extend Nested.NestedLevelOne {
 
 service ResourceService {
   rpc Find (ResourceFindRequest) returns (Resource);
+  rpc FindWithRpcFailed (ResourceFindRequest) returns (Resource);
   rpc FindWithSleep (ResourceSleepRequest) returns (Resource);
 }

--- a/spec/support/test/resource_service.rb
+++ b/spec/support/test/resource_service.rb
@@ -17,5 +17,10 @@ module Test
       response.name = 'Request should have timed out'
     end
 
+    # request -> Test::ResourceFindRequest
+    # response -> Test::Resource
+    def find_with_rpc_failed
+      rpc_failed('Find failed')
+    end
   end
 end


### PR DESCRIPTION
Before, the request wrapper was the only thing decoded in request decoder. The request was decoded inside the service and the service dispatcher handled parsing the service and method names into the RPC service and method. This made it impossible to interact with the request or various request meta data in middlewares without doing everything being done in the service dispatcher. It also made the dispatcher responsible for a lot of validation enforcement.
#### Decode everything

Instead, the whole request wrapper, including the request is decoded in the request decoder and the env is populated with the meta data so it's available to other middlewares that might need it.
#### Meta

Additional data now included in the env:
- Decoded request
- RPC method definition
- Request type for the given RPC method
- Response type for the given RPC method
- RPC service class
#### Rpc::Service

Since the service is no longer decoding the request, it is initialized with the env object, which contains everything it needs. This has the added benefit of making the env available inside any RPC endpoint.

// @localshred @abrandoned 
