### PR TITLE
Bump version to 3.0.0.alpha for development

### DIFF
--- a/lib/protobuf/version.rb
+++ b/lib/protobuf/version.rb
@@ -1,4 +1,4 @@
 module Protobuf
-  VERSION = '2.8.12'
+  VERSION = '3.0.0.alpha'
   PROTOC_VERSION = '2.5.0'
 end


### PR DESCRIPTION
Since we've been developing 3.0.0 in master, let's bump the version. This helps in updating dependent gems as we can update the gemspec to depend on 3.0.0.alpha or greater and update the Gemfile to point to master. This will lock the version in and make it easier to enforce the dependencies.
