### PR TITLE
Add load hooks for the middleware

### DIFF
--- a/lib/protobuf/rpc/client.rb
+++ b/lib/protobuf/rpc/client.rb
@@ -163,8 +163,6 @@ module Protobuf
 
     end
 
-    if ActiveSupport::VERSION::MAJOR > 2
-      ActiveSupport.run_load_hooks(:protobuf_rpc_client, Client)
-    end
+    ActiveSupport.run_load_hooks(:protobuf_rpc_client, Client)
   end
 end

--- a/lib/protobuf/rpc/middleware.rb
+++ b/lib/protobuf/rpc/middleware.rb
@@ -20,4 +20,6 @@ module Protobuf
   Rpc.middleware.use(Rpc::Middleware::RequestDecoder)
   Rpc.middleware.use(Rpc::Middleware::Logger)
   Rpc.middleware.use(Rpc::Middleware::ResponseEncoder)
+
+  ActiveSupport.run_load_hooks(:protobuf_rpc_middleware, Rpc)
 end

--- a/lib/protobuf/rpc/service.rb
+++ b/lib/protobuf/rpc/service.rb
@@ -176,8 +176,6 @@ module Protobuf
       end
     end
 
-    if ActiveSupport::VERSION::MAJOR > 2
-      ActiveSupport.run_load_hooks(:protobuf_rpc_service, Service)
-    end
+    ActiveSupport.run_load_hooks(:protobuf_rpc_service, Service)
   end
 end

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -19,7 +19,7 @@ require "protobuf/version"
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport'
+  s.add_dependency 'activesupport', '>= 2'
   s.add_dependency 'middleware'
   s.add_dependency 'multi_json'
   s.add_dependency 'thor'


### PR DESCRIPTION
Add Active Support load hooks for the middleware stack to make it easier to load middlewares into the stack.

Bump the minimum version of AS up to 2.0 since it's (at least) what we need to load middlewares and older versions are no longer supported.

// @localshred
