### PR TITLE
Pass in the defined type when building a field

### DIFF
--- a/lib/protobuf/field.rb
+++ b/lib/protobuf/field.rb
@@ -42,10 +42,14 @@ module Protobuf
     }.freeze
 
     def self.build(message_class, rule, type, name, tag, options = {})
-      field_type(type).new(message_class, rule, type, name, tag, options)
+      field_class(type).new(message_class, rule, field_type(type), name, tag, options)
     end
 
-    def self.field_type(type)
+    # Returns the field class for primitives,
+    # EnumField for types that inherit from Protobuf::Enum,
+    # and MessageField for types that inherit from Protobuf::Message.
+    #
+    def self.field_class(type)
       if PRIMITIVE_FIELD_MAP.key?(type)
         PRIMITIVE_FIELD_MAP[type]
       elsif type < ::Protobuf::Enum
@@ -57,6 +61,13 @@ module Protobuf
       else
         raise ArgumentError, "Invalid field type #{type}"
       end
+    end
+
+    # Returns the mapped type for primitives,
+    # otherwise the given type is returned.
+    #
+    def self.field_type(type)
+      PRIMITIVE_FIELD_MAP.fetch(type) { type }
     end
 
   end

--- a/spec/lib/protobuf/field_spec.rb
+++ b/spec/lib/protobuf/field_spec.rb
@@ -7,28 +7,32 @@ describe ::Protobuf::Field do
     pending
   end
 
-  describe '.field_type' do
+  describe '.field_class' do
     context 'when type is an enum class' do
       it 'returns an enum field' do
-        expect(subject.field_type(::Test::EnumTestType)).to eq(::Protobuf::Field::EnumField)
+        expect(subject.field_class(::Test::EnumTestType)).to eq(::Protobuf::Field::EnumField)
+        expect(subject.field_type(::Test::EnumTestType)).to eq(::Test::EnumTestType)
       end
     end
 
     context 'when type is a message class' do
       it 'returns a message field' do
-        expect(subject.field_type(::Test::Resource)).to eq(::Protobuf::Field::MessageField)
+        expect(subject.field_class(::Test::Resource)).to eq(::Protobuf::Field::MessageField)
+        expect(subject.field_type(::Test::Resource)).to eq(::Test::Resource)
       end
     end
 
     context 'when type is a base field class' do
       it 'returns that class' do
-        expect(subject.field_type(::Protobuf::Field::BoolField)).to eq(::Protobuf::Field::BoolField)
+        expect(subject.field_class(::Protobuf::Field::BoolField)).to eq(::Protobuf::Field::BoolField)
       end
     end
 
     context 'when type is a double field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::DoubleField
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:double)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:double)).to eq(expected_field)
       end
@@ -37,6 +41,8 @@ describe ::Protobuf::Field do
     context 'when type is a float field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::FloatField
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:float)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:float)).to eq(expected_field)
       end
@@ -45,6 +51,8 @@ describe ::Protobuf::Field do
     context 'when type is a int32 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Int32Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:int32)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:int32)).to eq(expected_field)
       end
@@ -53,6 +61,8 @@ describe ::Protobuf::Field do
     context 'when type is a int64 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Int64Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:int64)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:int64)).to eq(expected_field)
       end
@@ -61,6 +71,8 @@ describe ::Protobuf::Field do
     context 'when type is a uint32 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Uint32Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:uint32)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:uint32)).to eq(expected_field)
       end
@@ -69,6 +81,8 @@ describe ::Protobuf::Field do
     context 'when type is a uint64 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Uint64Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:uint64)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:uint64)).to eq(expected_field)
       end
@@ -77,6 +91,8 @@ describe ::Protobuf::Field do
     context 'when type is a sint32 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Sint32Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:sint32)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:sint32)).to eq(expected_field)
       end
@@ -85,6 +101,8 @@ describe ::Protobuf::Field do
     context 'when type is a sint64 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Sint64Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:sint64)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:sint64)).to eq(expected_field)
       end
@@ -93,6 +111,8 @@ describe ::Protobuf::Field do
     context 'when type is a fixed32 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Fixed32Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:fixed32)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:fixed32)).to eq(expected_field)
       end
@@ -101,6 +121,8 @@ describe ::Protobuf::Field do
     context 'when type is a fixed64 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Fixed64Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:fixed64)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:fixed64)).to eq(expected_field)
       end
@@ -109,6 +131,8 @@ describe ::Protobuf::Field do
     context 'when type is a sfixed32 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Sfixed32Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:sfixed32)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:sfixed32)).to eq(expected_field)
       end
@@ -117,6 +141,8 @@ describe ::Protobuf::Field do
     context 'when type is a sfixed64 field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::Sfixed64Field
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:sfixed64)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:sfixed64)).to eq(expected_field)
       end
@@ -126,6 +152,8 @@ describe ::Protobuf::Field do
     context 'when type is a string field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::StringField
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:string)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:string)).to eq(expected_field)
       end
@@ -135,6 +163,8 @@ describe ::Protobuf::Field do
     context 'when type is a bytes field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::BytesField
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:bytes)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:bytes)).to eq(expected_field)
       end
@@ -144,6 +174,8 @@ describe ::Protobuf::Field do
     context 'when type is a bool field class or symbol' do
       it 'returns that class' do
         expected_field = ::Protobuf::Field::BoolField
+        expect(subject.field_class(expected_field)).to eq(expected_field)
+        expect(subject.field_class(:bool)).to eq(expected_field)
         expect(subject.field_type(expected_field)).to eq(expected_field)
         expect(subject.field_type(:bool)).to eq(expected_field)
       end
@@ -152,7 +184,7 @@ describe ::Protobuf::Field do
     context 'when type is not mapped' do
       it 'raises an ArgumentError' do
         expect {
-          subject.field_type("boom")
+          subject.field_class("boom")
         }.to raise_error
       end
     end


### PR DESCRIPTION
When the field class is enum or message we need to pass the actual class as
the type, not EnumField or MessageField (or symbol).

This is because for messages and enums, we expect to be dealing with a
message/enum instance instead of the field instance.

Example

``` ruby
  class Foo < ::Protobuf::Message
    # expands to Protobuf::Field::StringField.new(Foo, :optional, Protobuf::FieldString, :name, 1, {})
    optional :string, :name, 1
  end

  # Notice the difference between what we're initializing and
  # what we're passing as the type (Foo in this case, not MessageField)
  class Bar < Protobuf::Message
    # expands to Protobuf::Field::MessageField.new(Bar, :optional, Foo, :foo, 1, {})
    optional Foo, :foo, 1
  end
```
