### PR TITLE
Require Active Support 3.2+

### DIFF
--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -2,18 +2,10 @@ require 'logger'
 require 'socket'
 require 'pp'
 require 'stringio'
+
 require 'active_support/core_ext/object/blank'
-require 'active_support/version'
+require 'active_support/core_ext/object/try'
 require 'active_support/notifications'
-
-if ActiveSupport::VERSION::MAJOR > 2
-  require 'active_support/core_ext/object/try'
-else
-  require 'active_support/core_ext/module/delegation'
-  require 'active_support/core_ext/kernel/reporting'
-  require 'active_support/core_ext/try'
-end
-
 require 'active_support/inflector'
 require 'active_support/json'
 

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -19,7 +19,7 @@ require "protobuf/version"
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport', '>= 2'
+  s.add_dependency 'activesupport', '>= 3.2'
   s.add_dependency 'middleware'
   s.add_dependency 'multi_json'
   s.add_dependency 'thor'


### PR DESCRIPTION
Since this is a major version bump, and Rails is about to release v4.1, we should be able to safely require Active Support 3.2+. This eliminates all branching for versions less than 2.0.

// @localshred @abrandoned 
