### PR TITLE
not sure if AR issue but getting errors with repeated

### DIFF
--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -182,17 +182,11 @@ module Protobuf
           define_method(field.setter_method_name) do |val|
             field.warn_if_deprecated
 
-            if val.is_a?(Array)
-              val = val.dup
-              val.compact!
-            else
-              raise TypeError, <<-TYPE_ERROR
-                Expected repeated value of type '#{field.type_class}'
-                Got '#{val.class}' for repeated protobuf field #{field.name}
-              TYPE_ERROR
-            end
+            val = [ val ] unless val.is_a?(Array)
+            val = val.dup
+            val.compact!
 
-            if val.nil? || (val.respond_to?(:empty?) && val.empty?)
+            if val.respond_to?(:empty?) && val.empty?
               @values.delete(field.name)
             else
               @values[field.name] ||= ::Protobuf::Field::FieldArray.new(field)


### PR DESCRIPTION
fields as they are not being set to an array and need
to be wrapped when they come in

Maybe @liveh2o can weigh in, I couldn't get the pb 3 series running with ActiveRemote (as a client) unless I added this change that wraps the repeated value if it isn't wrapped when it comes in (worked as a server just fine)
