### PR TITLE
requests can be "lost" because [].shift is nil

### DIFF
--- a/lib/protobuf/rpc/servers/zmq/broker.rb
+++ b/lib/protobuf/rpc/servers/zmq/broker.rb
@@ -25,6 +25,10 @@ module Protobuf
           @idle_workers = []
 
           loop do
+            unless local_queue.empty?
+              process_local_queue
+            end
+
             rc = @poller.poll(500)
 
             # The server was shutdown and no requests are pending
@@ -34,10 +38,6 @@ module Protobuf
             break if rc == -1
 
             @poller.readables.each do |readable|
-              unless local_queue.empty?
-                process_local_queue
-              end
-
               case readable
               when @frontend_socket
                 process_frontend


### PR DESCRIPTION
this means that when all workers are busy they can lose
a request that comes in when it tries to shift off a worker

this PR adds a local queue that will queue that request until
a worker is available to work that queue

fixes #188 

@localshred 
