### PR TITLE
Message.to_json returns the name of the class

### DIFF
--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -15,8 +15,17 @@ module Protobuf
     include ::Protobuf::Message::Serialization
 
     ##
+    # Class Methods
+    #
+
+    def self.to_json
+      name
+    end
+
+    ##
     # Constructor
     #
+
     def initialize(fields = {})
       @values = {}
 

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -289,6 +289,16 @@ describe Protobuf::Message do
     its(:to_json) { should eq '{"name":"Test Name","active":false}' }
   end
 
+  describe '.to_json' do
+    it 'returns the class name of the message for use in json encoding' do
+      expect {
+        ::Timeout.timeout(0.1) do
+          expect(::Test::Resource.to_json).to eq("Test::Resource")
+        end
+      }.not_to raise_error
+    end
+  end
+
   describe "#define_setter" do
     subject { ::Test::Resource.new }
 


### PR DESCRIPTION
This fixes a long-standing bug caused by circular references in the way the
Field system is implemented.

The spec wraps the call to to_json in a timeout because the recursive checks
are unbounded and will eat memory and cpu forever. The simplest solution is to
simply return the name of the message when asked for the json representation
at the class level.

h/t to @abrandoned and @liveh2o for finding this insane bug.
