### PR TITLE
Backport Message.to_json fix from 974f3619 to 2.8 branch

### DIFF
--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -122,6 +122,11 @@ module Protobuf
       define_field(:required, type, name, tag, options)
     end
 
+    # Backported fix to prevent recursive to_json issues.
+    def self.to_json
+      name
+    end
+
     ##
     # Constructor
     #

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -289,6 +289,16 @@ describe Protobuf::Message do
     its(:to_json) { should eq '{"name":"Test Name","active":false}' }
   end
 
+  describe '.to_json' do
+    it 'returns the class name of the message for use in json encoding' do
+      expect {
+        ::Timeout.timeout(0.1) do
+          expect(::Test::Resource.to_json).to eq("Test::Resource")
+        end
+      }.not_to raise_error
+    end
+  end
+
   describe '#get_field_by_name' do
     subject do
       ::Test::Resource.new({ :name => 'Test Name', :date_created => Time.now.to_i })


### PR DESCRIPTION
See 974f3619 and #190 for original fix. This is a
backport from 3.0.3 to 2.8.
