### PR TITLE
Handle unknown enums when decoding

### DIFF
--- a/lib/protobuf/field/enum_field.rb
+++ b/lib/protobuf/field/enum_field.rb
@@ -16,6 +16,12 @@ module Protobuf
         super(value.to_i)
       end
 
+      def decode(value)
+        if acceptable?(value)
+          value
+        end
+      end
+
       def enum?
         true
       end


### PR DESCRIPTION
The current behavior of this gem is that it will raise when deserializing an enum field with an unknown value. I believe this is undesirable because it is not forwards compatible.

This behavior matches the Python implementation (and I believe Java too, but have not confirmed) that allows enums fields to be populated with unknown int value.

``` python
# python
enum = TestMessage.EnumField.items()
# [('ONE', 1), ('TWO', 2)]
msg = TestMessage()
msg.enum_field # default, unset value
#0
msg.enum_field = 100
msg.enum_field
#100
```

Would love some feedback on this approach, thanks!
