### PR TITLE
Enums should be able to have negative values

### DIFF
--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -236,4 +236,31 @@ describe Protobuf::Enum do
   context 'when coercing from integer' do
     specify { expect(0).to eq(Test::StatusType::PENDING) }
   end
+
+  context 'negative enum values' do
+    before(:all) do
+      EnumNegativeValueTest = ::Class.new(::Protobuf::Enum) do
+        define :POSITIVE, 1
+        define :ZERO, 0
+        define :NEGATIVE, -1
+      end
+
+      NegativeEnumMessageTest = ::Class.new(::Protobuf::Message) do
+        optional EnumNegativeValueTest, :negative_enum_test, 1
+      end
+    end
+
+    it 'should encode a negative enum value' do
+      expect {
+        NegativeEnumMessageTest.encode(:negative_enum_test => -1)
+      }.not_to raise_exception
+    end
+
+    it 'should decode a negative enum value' do
+      expect {
+        encoded = NegativeEnumMessageTest.encode(:negative_enum_test => -1)
+        NegativeEnumMessageTest.decode(encoded)
+      }.not_to raise_exception
+    end
+  end
 end


### PR DESCRIPTION
When a protobuf is defined such that it contains an enum with a negative value, we can encode it but not decode it.  (I'm not sure whether the error occurs in encoding or decoding, but that might be interesting to know.)

Repro script here: https://gist.github.com/ismith/b17e9b31d696195169df

Note that although discouraged, the spec does allow enums to have negative values: "Enumerator constants must be in the range of a 32-bit integer. Since enum values use varint encoding on the wire, negative values are inefficient and thus not recommended." from https://developers.google.com/protocol-buffers/docs/proto

(Looks like at least one other protobuf implementation has run into this, too: https://github.com/dcodeIO/ProtoBuf.js/issues/34)
