### PR TITLE
Stricter validation in Message#initialize for non-existent fields

### DIFF
--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -83,6 +83,19 @@ module Protobuf
     @_print_deprecation_warnings = !!value
   end
 
+  # Permit unknown field on Message initialization
+  #
+  # Default: true
+  #
+  # Simple boolean to define whether we want to permit unknown fields
+  # on Message intialization; otherwise a ::Protobuf::FieldNotDefinedError is thrown.
+  def self.ignore_unknown_fields?
+    !defined?(@_ignore_unknown_fields) || @_ignore_unknown_fields
+  end
+
+  def self.ignore_unknown_fields=(value)
+    @_ignore_unknown_fields = !!value
+  end
 end
 
 unless ENV.key?('PB_NO_NETWORKING')

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -30,7 +30,7 @@ module Protobuf
       @values = {}
 
       fields.to_hash.each_pair do |name, value|
-        self[name] = value unless value.nil?
+        self[name] = value
       end
     end
 
@@ -135,7 +135,11 @@ module Protobuf
 
     def []=(name, value)
       if field = self.class.get_field(name, true)
-        __send__(field.setter_method_name, value)
+        __send__(field.setter_method_name, value) unless value.nil?
+      else
+        unless ::Protobuf.ignore_unknown_fields?
+          raise ::Protobuf::FieldNotDefinedError, name
+        end
       end
     end
 

--- a/spec/lib/protobuf_spec.rb
+++ b/spec/lib/protobuf_spec.rb
@@ -75,4 +75,24 @@ describe ::Protobuf do
     end
   end
 
+  describe '.ignore_unknown_fields?' do
+    before do
+      if described_class.instance_variable_defined?(:@_ignore_unknown_fields)
+        described_class.send(:remove_instance_variable, :@_ignore_unknown_fields)
+      end
+    end
+
+    it 'defaults to a true value' do
+      expect(described_class.ignore_unknown_fields?).to be true
+    end
+
+    it 'is settable' do
+      expect {
+        described_class.ignore_unknown_fields = false
+      }.to change {
+        described_class.ignore_unknown_fields?
+      }.from(true).to(false)
+    end
+  end
+
 end


### PR DESCRIPTION
My colleagues and I noticed that `Message#initialize` and `Message.encode` silently drop fields that aren't actually part of the proto. This PR makes the validation explicit, and throws a `Protobuf::FieldNotDefinedError` in that situation.

Alternatively, we could introduce backwards compatible `#initialize!` and `.encode!`. However, I think it would be a big win for this gem to enforce the schema of the protobuf to this extent.

Please take a look, and thanks for all your work for this Gem!

cc @tamird
