### PR TITLE
More state cleanup in BaseField, alphabetizing

### DIFF
--- a/lib/protobuf/field/bool_field.rb
+++ b/lib/protobuf/field/bool_field.rb
@@ -40,7 +40,7 @@ module Protobuf
 
         field = self
         message_class.class_eval do
-          define_method("#{field.getter_method_name}?") do
+          define_method("#{field.getter}?") do
             field.warn_if_deprecated
             @values.fetch(field.name, field.default_value)
           end

--- a/lib/protobuf/field/bytes_field.rb
+++ b/lib/protobuf/field/bytes_field.rb
@@ -54,7 +54,7 @@ module Protobuf
       def define_setter
         field = self
         message_class.class_eval do
-          define_method(field.setter_method_name) do |val|
+          define_method(field.setter) do |val|
             begin
               field.warn_if_deprecated
               val = "#{val}" if val.is_a?(Symbol)

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -62,7 +62,7 @@ module Protobuf
     #
     def each_field
       self.class.all_fields.each do |field|
-        value = __send__(field.name)
+        value = __send__(field.getter)
         yield(field, value)
       end
     end
@@ -71,7 +71,7 @@ module Protobuf
       self.class.all_fields.each do |field|
         next unless field_must_be_serialized?(field)
 
-        value = @values[field.name]
+        value = @values[field.getter]
 
         if value.nil?
           raise ::Protobuf::SerializationError, "Required field #{self.class.name}##{field.name} does not have a value."
@@ -129,13 +129,13 @@ module Protobuf
 
     def [](name)
       if field = self.class.get_field(name, true)
-        __send__(field.name)
+        __send__(field.getter)
       end
     end
 
     def []=(name, value)
       if field = self.class.get_field(name, true)
-        __send__(field.setter_method_name, value) unless value.nil?
+        __send__(field.setter, value) unless value.nil?
       else
         unless ::Protobuf.ignore_unknown_fields?
           raise ::Protobuf::FieldNotDefinedError, name


### PR DESCRIPTION
Finishing off what @tamird started in #205.

Alphabetize all methods in BaseField.

Rather than deleting values out of the options hash, reference the hash
from predicate functions.

Rename `getter_method_name` and `setter_method_name` to simpler
`getter` and `setter`.

Remove the excess options warning since we are generating all field
definitions.
