### PR TITLE
Return executable control after compile

### DIFF
--- a/lib/protobuf/tasks/compile.rake
+++ b/lib/protobuf/tasks/compile.rake
@@ -23,7 +23,7 @@ namespace :protobuf do
     full_command = command.join(' ')
 
     puts full_command
-    exec(full_command)
+    system(full_command)
   end
 
   desc 'Clean the generated *.pb.rb files from the destination package. Pass PB_FORCE_CLEAN=1 to skip confirmation step.'


### PR DESCRIPTION
I need to call the rake compile task twice within our rake file, but because of the use of exec instead of system, control is never returned to our calling rake task. This patch allows control to go back to the calling process.

@localshred
