### PR TITLE
Add support for deprecated messages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,20 +15,22 @@ task :default => :spec
 RSpec::Core::RakeTask.new(:spec)
 
 desc 'Run both the spec and descriptors compilation tasks'
-task :compile => [ 'compile:spec', 'compile:descriptors' ]
+task :compile, [ :protoc_program_name ] => [ 'compile:spec', 'compile:descriptors' ]
 
 desc 'Run specs'
 namespace :compile do
 
   desc 'Compile spec protos in spec/supprt/ directory'
-  task :spec do |task, args|
-    source = ::File.expand_path('../spec/support/', __FILE__)
+  task :spec, [ :protoc_program_name ] do |task, args|
+    args.with_defaults(:protoc_program_name => 'protoc')
+
+    source      = ::File.expand_path('../spec/support/', __FILE__)
     input_files = ::File.join(source, '**', '*.proto')
     destination = source
 
     command = []
     command << "PB_NO_TAG_WARNINGS=1"
-    command << "protoc --plugin=./bin/protoc-gen-ruby"
+    command << "#{args[:protoc_program_name]} --plugin=./bin/protoc-gen-ruby"
     command << "--ruby_out=#{destination}"
     command << "-I #{source}"
     command << Dir[input_files].join(' ')
@@ -39,7 +41,9 @@ namespace :compile do
   end
 
   desc 'Compile rpc protos in protos/ directory'
-  task :descriptors do |task, args|
+  task :descriptors, [ :protoc_program_name ] do |task, args|
+    args.with_defaults(:protoc_program_name => 'protoc')
+
     source      = ::File.expand_path('../proto', __FILE__)
     input_files = ::File.join(source, '**', '*.proto')
     destination = ::File.expand_path('../tmp/rpc', __FILE__)
@@ -47,7 +51,7 @@ namespace :compile do
 
     command = []
     command << "PB_NO_TAG_WARNINGS=1"
-    command << "protoc --plugin=./bin/protoc-gen-ruby"
+    command << "#{args[:protoc_program_name]} --plugin=./bin/protoc-gen-ruby"
     command << "--ruby_out=#{destination}"
     command << "-I #{source}"
     command << Dir[input_files].join(' ')

--- a/lib/protobuf/generators/group_generator.rb
+++ b/lib/protobuf/generators/group_generator.rb
@@ -3,6 +3,7 @@ require 'protobuf/generators/extension_generator'
 require 'protobuf/generators/field_generator'
 require 'protobuf/generators/message_generator'
 require 'protobuf/generators/oneof_generator'
+require 'protobuf/generators/option_method_generator'
 require 'protobuf/generators/service_generator'
 
 module Protobuf
@@ -75,6 +76,12 @@ module Protobuf
       def add_oneof_names(descriptor)
         unless descriptor.oneof_decl.empty?
           @groups[:oneof_descriptors] << OneofGenerator.new(descriptor, indent_level)
+        end
+      end
+
+      def add_option_method(method_name, option_field_name, options_descriptor)
+        unless options_descriptor.nil?
+          @groups[:options] << OptionMethodGenerator.new(method_name, option_field_name, options_descriptor, indent_level)
         end
       end
 

--- a/lib/protobuf/generators/message_generator.rb
+++ b/lib/protobuf/generators/message_generator.rb
@@ -43,6 +43,8 @@ module Protobuf
               group = GroupGenerator.new(current_indent)
               group.add_messages(descriptor.nested_type, :extension_fields => @extension_fields, :namespace => type_namespace)
 
+              group.add_option_method(:deprecated?, :deprecated, descriptor.options)
+
               group.add_oneof_names(descriptor)
               group.add_message_fields(descriptor.field, descriptor.oneof_decl)
               self.class.validate_tags(fully_qualified_type_namespace, descriptor.field.map(&:number))
@@ -54,7 +56,7 @@ module Protobuf
 
               group.add_extension_fields(message_extension_fields, descriptor.oneof_decl)
 
-              group.order = [ :message, :oneof_descriptors, :field, :extension_range, :extension_field ]
+              group.order = [ :message, :options, :oneof_descriptors, :field, :extension_range, :extension_field ]
               print group.to_s
             end
           end
@@ -69,6 +71,10 @@ module Protobuf
 
       def has_fields?
         descriptor.field.count > 0
+      end
+
+      def has_options?
+        ! descriptor.options.nil?
       end
 
       def has_nested_enums?
@@ -87,7 +93,7 @@ module Protobuf
         if @only_declarations
           has_nested_types?
         else
-          has_fields? || has_nested_messages? || has_extensions?
+          has_fields? || has_nested_messages? || has_extensions? || has_options?
         end
       end
 

--- a/lib/protobuf/generators/option_method_generator.rb
+++ b/lib/protobuf/generators/option_method_generator.rb
@@ -1,0 +1,28 @@
+require 'protobuf/generators/base'
+
+module Protobuf
+  module Generators
+    class OptionMethodGenerator < Base
+
+      attr_accessor :method_name, :option_field_name
+
+      def initialize(method_name, option_field_name, options_descriptor, indent_level = 0)
+        self.method_name = method_name
+        self.option_field_name = option_field_name
+        super(options_descriptor, indent_level)
+      end
+
+      def compile
+        run_once(:compile) do
+          puts "def self.#{method_name}"
+          indent { puts self.descriptor[option_field_name].to_s }
+          puts "end"
+          puts
+        end
+      end
+
+    end
+  end
+end
+
+

--- a/lib/protobuf/message/fields.rb
+++ b/lib/protobuf/message/fields.rb
@@ -70,6 +70,11 @@ module Protobuf
         RAW_GETTER
       end
 
+      # To be overriden by inheriting messages
+      def deprecated?
+        false
+      end
+
       def extension_fields
         @extension_fields ||= all_fields.select(&:extension?)
       end

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -513,6 +513,10 @@ describe Protobuf::Message do
       expect(::Test::DeprecatedMessage).to respond_to(:deprecated?)
     end
 
+    it 'specifies at a class level when a message has been deprecated' do
+      expect(::Test::Resource.deprecated?).to be_falsey
+      expect(::Test::DeprecatedMessage.deprecated?).to be_truthy
+    end
   end
 
 end

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -508,4 +508,11 @@ describe Protobuf::Message do
     end
   end
 
+  describe 'deprecated messages' do
+    it 'specifies at a class level when a message has been deprecated' do
+      expect(::Test::DeprecatedMessage).to respond_to(:deprecated?)
+    end
+
+  end
+
 end

--- a/spec/support/test/deprecated.pb.rb
+++ b/spec/support/test/deprecated.pb.rb
@@ -1,0 +1,25 @@
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf/message'
+
+module Test
+
+  ##
+  # Message Classes
+  #
+  class DeprecatedMessage < ::Protobuf::Message; end
+
+
+  ##
+  # Message Fields
+  #
+  class DeprecatedMessage
+    def self.deprecated?
+      true
+    end
+
+  end
+
+end
+

--- a/spec/support/test/deprecated.proto
+++ b/spec/support/test/deprecated.proto
@@ -1,0 +1,5 @@
+package test;
+
+message DeprecatedMessage {
+  option deprecated = true;
+}


### PR DESCRIPTION
When using the deprecated option on a message, we compile a class-level
`deprecated?` method.

``` protobuf
package test;

message DeprecatedMessage {
  option deprecated = true;
}
```

...compiles down to...

``` ruby
require 'protobuf/message'

module Test
  class DeprecatedMessage < ::Protobuf::Message; end
  class DeprecatedMessage
    def self.deprecated?
      true
    end
  end
end
```

See #212 and #211 for related 2.6 features.
