### PR TITLE
Add support for deprecated enums and enum values

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,20 +15,22 @@ task :default => :spec
 RSpec::Core::RakeTask.new(:spec)
 
 desc 'Run both the spec and descriptors compilation tasks'
-task :compile => [ 'compile:spec', 'compile:descriptors' ]
+task :compile, [ :protoc_program_name ] => [ 'compile:spec', 'compile:descriptors' ]
 
 desc 'Run specs'
 namespace :compile do
 
   desc 'Compile spec protos in spec/supprt/ directory'
-  task :spec do |task, args|
-    source = ::File.expand_path('../spec/support/', __FILE__)
+  task :spec, [ :protoc_program_name ] do |task, args|
+    args.with_defaults(:protoc_program_name => 'protoc')
+
+    source      = ::File.expand_path('../spec/support/', __FILE__)
     input_files = ::File.join(source, '**', '*.proto')
     destination = source
 
     command = []
     command << "PB_NO_TAG_WARNINGS=1"
-    command << "protoc --plugin=./bin/protoc-gen-ruby"
+    command << "#{args[:protoc_program_name]} --plugin=./bin/protoc-gen-ruby"
     command << "--ruby_out=#{destination}"
     command << "-I #{source}"
     command << Dir[input_files].join(' ')
@@ -39,7 +41,9 @@ namespace :compile do
   end
 
   desc 'Compile rpc protos in protos/ directory'
-  task :descriptors do |task, args|
+  task :descriptors, [ :protoc_program_name ] do |task, args|
+    args.with_defaults(:protoc_program_name => 'protoc')
+
     source      = ::File.expand_path('../proto', __FILE__)
     input_files = ::File.join(source, '**', '*.proto')
     destination = ::File.expand_path('../tmp/rpc', __FILE__)
@@ -47,7 +51,7 @@ namespace :compile do
 
     command = []
     command << "PB_NO_TAG_WARNINGS=1"
-    command << "protoc --plugin=./bin/protoc-gen-ruby"
+    command << "#{args[:protoc_program_name]} --plugin=./bin/protoc-gen-ruby"
     command << "--ruby_out=#{destination}"
     command << "-I #{source}"
     command << Dir[input_files].join(' ')

--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -273,6 +273,10 @@ module Protobuf
       Fixnum
     end
 
+    def deprecated?
+      options.key?(:deprecated)
+    end
+
     def inspect
       "\#<Protobuf::Enum(#{parent_class})::#{name}=#{tag}>"
     end

--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -69,8 +69,8 @@ module Protobuf
     #
     # Returns nothing.
     #
-    def self.define(name, tag)
-      enum = self.new(self, name, tag)
+    def self.define(name, tag, options = {})
+      enum = self.new(self, name, tag, options)
       @enums ||= []
       @enums << enum
       const_set(name, enum)
@@ -253,16 +253,17 @@ module Protobuf
     # Attributes
     #
 
-    attr_reader :parent_class, :name, :tag
+    attr_reader :parent_class, :name, :options, :tag
 
     ##
     # Instance Methods
     #
 
-    def initialize(parent_class, name, tag)
+    def initialize(parent_class, name, tag, options = {})
       @parent_class = parent_class
       @name = name
       @tag = tag
+      @options = options
       super(@tag)
     end
 

--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -76,6 +76,12 @@ module Protobuf
       const_set(name, enum)
     end
 
+    # Public: Indicate the enum's deprecated status. Intended to be overidden.
+    #
+    def self.deprecated?
+      false
+    end
+
     # Public: All defined enums.
     #
     def self.enums

--- a/lib/protobuf/generators/enum_generator.rb
+++ b/lib/protobuf/generators/enum_generator.rb
@@ -13,6 +13,13 @@ module Protobuf
           tags = []
 
           print_class(descriptor.name, :enum) do
+            if deprecated?
+              puts "def self.deprecated?"
+              indent { puts "true" }
+              puts "end"
+              puts
+            end
+
             if allow_alias?
               puts "set_option :allow_alias"
               puts
@@ -34,6 +41,10 @@ module Protobuf
         name = enum_value_descriptor.name
         number = enum_value_descriptor.number
         return "define :#{name}, #{number}"
+      end
+
+      def deprecated?
+        descriptor.options.try(:deprecated!) { false }
       end
 
     end

--- a/lib/protobuf/generators/enum_generator.rb
+++ b/lib/protobuf/generators/enum_generator.rb
@@ -55,7 +55,7 @@ module Protobuf
       end
 
       def deprecated_value?(enum_value_descriptor)
-        enum_value_descriptor.options.try(:deprecated!) { false }
+        deprecated? || enum_value_descriptor.options.try(:deprecated!) { false }
       end
 
     end

--- a/lib/protobuf/generators/enum_generator.rb
+++ b/lib/protobuf/generators/enum_generator.rb
@@ -38,13 +38,24 @@ module Protobuf
       end
 
       def build_value(enum_value_descriptor)
-        name = enum_value_descriptor.name
-        number = enum_value_descriptor.number
-        return "define :#{name}, #{number}"
+        value_definition = [
+          ":#{enum_value_descriptor.name}",
+          enum_value_descriptor.number
+        ]
+
+        options = {}
+        options[:deprecated] = true if deprecated_value?(enum_value_descriptor)
+        options.each { |k, v| value_definition << ":#{k} => #{v}" }
+
+        return "define " + value_definition.join(', ')
       end
 
       def deprecated?
         descriptor.options.try(:deprecated!) { false }
+      end
+
+      def deprecated_value?(enum_value_descriptor)
+        enum_value_descriptor.options.try(:deprecated!) { false }
       end
 
     end

--- a/lib/protobuf/generators/group_generator.rb
+++ b/lib/protobuf/generators/group_generator.rb
@@ -3,6 +3,7 @@ require 'protobuf/generators/extension_generator'
 require 'protobuf/generators/field_generator'
 require 'protobuf/generators/message_generator'
 require 'protobuf/generators/oneof_generator'
+require 'protobuf/generators/option_method_generator'
 require 'protobuf/generators/service_generator'
 
 module Protobuf
@@ -75,6 +76,12 @@ module Protobuf
       def add_oneof_names(descriptor)
         unless descriptor.oneof_decl.empty?
           @groups[:oneof_descriptors] << OneofGenerator.new(descriptor, indent_level)
+        end
+      end
+
+      def add_option_method(method_name, option_field_name, options_descriptor)
+        unless options_descriptor.nil?
+          @groups[:options] << OptionMethodGenerator.new(method_name, option_field_name, options_descriptor, indent_level)
         end
       end
 

--- a/lib/protobuf/generators/message_generator.rb
+++ b/lib/protobuf/generators/message_generator.rb
@@ -43,6 +43,8 @@ module Protobuf
               group = GroupGenerator.new(current_indent)
               group.add_messages(descriptor.nested_type, :extension_fields => @extension_fields, :namespace => type_namespace)
 
+              group.add_option_method(:deprecated?, :deprecated, descriptor.options)
+
               group.add_oneof_names(descriptor)
               group.add_message_fields(descriptor.field, descriptor.oneof_decl)
               self.class.validate_tags(fully_qualified_type_namespace, descriptor.field.map(&:number))
@@ -54,7 +56,7 @@ module Protobuf
 
               group.add_extension_fields(message_extension_fields, descriptor.oneof_decl)
 
-              group.order = [ :message, :oneof_descriptors, :field, :extension_range, :extension_field ]
+              group.order = [ :message, :options, :oneof_descriptors, :field, :extension_range, :extension_field ]
               print group.to_s
             end
           end
@@ -69,6 +71,10 @@ module Protobuf
 
       def has_fields?
         descriptor.field.count > 0
+      end
+
+      def has_options?
+        ! descriptor.options.nil?
       end
 
       def has_nested_enums?
@@ -87,7 +93,7 @@ module Protobuf
         if @only_declarations
           has_nested_types?
         else
-          has_fields? || has_nested_messages? || has_extensions?
+          has_fields? || has_nested_messages? || has_extensions? || has_options?
         end
       end
 

--- a/lib/protobuf/generators/option_method_generator.rb
+++ b/lib/protobuf/generators/option_method_generator.rb
@@ -1,0 +1,28 @@
+require 'protobuf/generators/base'
+
+module Protobuf
+  module Generators
+    class OptionMethodGenerator < Base
+
+      attr_accessor :method_name, :option_field_name
+
+      def initialize(method_name, option_field_name, options_descriptor, indent_level = 0)
+        self.method_name = method_name
+        self.option_field_name = option_field_name
+        super(options_descriptor, indent_level)
+      end
+
+      def compile
+        run_once(:compile) do
+          puts "def self.#{method_name}"
+          indent { puts self.descriptor[option_field_name].to_s }
+          puts "end"
+          puts
+        end
+      end
+
+    end
+  end
+end
+
+

--- a/lib/protobuf/message/fields.rb
+++ b/lib/protobuf/message/fields.rb
@@ -70,6 +70,11 @@ module Protobuf
         RAW_GETTER
       end
 
+      # To be overriden by inheriting messages
+      def deprecated?
+        false
+      end
+
       def extension_fields
         @extension_fields ||= all_fields.select(&:extension?)
       end

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -236,4 +236,11 @@ describe Protobuf::Enum do
   context 'when coercing from integer' do
     specify { expect(0).to eq(Test::StatusType::PENDING) }
   end
+
+  describe 'deprecated messages' do
+    it 'specifies at a class level when an enum has been deprecated' do
+      expect(::Test::DeprecatedEnum).to respond_to(:deprecated?)
+    end
+
+  end
 end

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -242,6 +242,10 @@ describe Protobuf::Enum do
       expect(::Test::DeprecatedEnum).to respond_to(:deprecated?)
     end
 
+    it 'allows deprecation of enum values' do
+      expect(::Test::StatusType::PENDING).to respond_to(:deprecated?)
+    end
+
     it 'specifies at a class level when a message has been deprecated' do
       expect(::Test::StatusType.deprecated?).to be_falsey
       expect(::Test::DeprecatedEnum.deprecated?).to be_truthy

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -242,5 +242,9 @@ describe Protobuf::Enum do
       expect(::Test::DeprecatedEnum).to respond_to(:deprecated?)
     end
 
+    it 'specifies at a class level when a message has been deprecated' do
+      expect(::Test::StatusType.deprecated?).to be_falsey
+      expect(::Test::DeprecatedEnum.deprecated?).to be_truthy
+    end
   end
 end

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -250,5 +250,10 @@ describe Protobuf::Enum do
       expect(::Test::StatusType.deprecated?).to be_falsey
       expect(::Test::DeprecatedEnum.deprecated?).to be_truthy
     end
+
+    it 'specifies when an enum value has been deprecated' do
+      expect(::Test::StatusType::PENDING.deprecated?).to be_falsey
+      expect(::Test::DeprecatedEnum::A_DEPRECATED_VALUE.deprecated?).to be_truthy
+    end
   end
 end

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -246,14 +246,14 @@ describe Protobuf::Enum do
       expect(::Test::StatusType::PENDING).to respond_to(:deprecated?)
     end
 
-    it 'specifies at a class level when a message has been deprecated' do
-      expect(::Test::StatusType.deprecated?).to be_falsey
-      expect(::Test::DeprecatedEnum.deprecated?).to be_truthy
-    end
+    it 'allows deprecating an entire enum along with all its values' do
+      expect(::Test::NonDeprecatedEnum.deprecated?).to be_falsey
+      expect(::Test::NonDeprecatedEnum::A_DEPRECATED_VALUE.deprecated?).to be_truthy
+      expect(::Test::NonDeprecatedEnum::NOT_DEPRECATED_VALUE.deprecated?).to be_falsey
 
-    it 'specifies when an enum value has been deprecated' do
-      expect(::Test::StatusType::PENDING.deprecated?).to be_falsey
-      expect(::Test::DeprecatedEnum::A_DEPRECATED_VALUE.deprecated?).to be_truthy
+      expect(::Test::DeprecatedEnum.deprecated?).to be_truthy
+      expect(::Test::DeprecatedEnum::EXPLICIT.deprecated?).to be_truthy
+      expect(::Test::DeprecatedEnum::IMPLICIT.deprecated?).to be_truthy
     end
   end
 end

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -513,6 +513,10 @@ describe Protobuf::Message do
       expect(::Test::DeprecatedMessage).to respond_to(:deprecated?)
     end
 
+    it 'specifies at a class level when a message has been deprecated' do
+      expect(::Test::Resource.deprecated?).to be_falsey
+      expect(::Test::DeprecatedMessage.deprecated?).to be_truthy
+    end
   end
 
 end

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -508,4 +508,11 @@ describe Protobuf::Message do
     end
   end
 
+  describe 'deprecated messages' do
+    it 'specifies at a class level when a message has been deprecated' do
+      expect(::Test::DeprecatedMessage).to respond_to(:deprecated?)
+    end
+
+  end
+
 end

--- a/spec/support/test/deprecated.pb.rb
+++ b/spec/support/test/deprecated.pb.rb
@@ -13,7 +13,7 @@ module Test
       true
     end
 
-    define :FOO, 1
+    define :A_DEPRECATED_VALUE, 1, :deprecated => true
   end
 
 

--- a/spec/support/test/deprecated.pb.rb
+++ b/spec/support/test/deprecated.pb.rb
@@ -8,12 +8,18 @@ module Test
   ##
   # Enum Classes
   #
+  class NonDeprecatedEnum < ::Protobuf::Enum
+    define :A_DEPRECATED_VALUE, 1, :deprecated => true
+    define :NOT_DEPRECATED_VALUE, 2
+  end
+
   class DeprecatedEnum < ::Protobuf::Enum
     def self.deprecated?
       true
     end
 
-    define :A_DEPRECATED_VALUE, 1, :deprecated => true
+    define :EXPLICIT, 1, :deprecated => true
+    define :IMPLICIT, 2, :deprecated => true
   end
 
 

--- a/spec/support/test/deprecated.pb.rb
+++ b/spec/support/test/deprecated.pb.rb
@@ -6,6 +6,18 @@ require 'protobuf/message'
 module Test
 
   ##
+  # Enum Classes
+  #
+  class DeprecatedEnum < ::Protobuf::Enum
+    def self.deprecated?
+      true
+    end
+
+    define :FOO, 1
+  end
+
+
+  ##
   # Message Classes
   #
   class DeprecatedMessage < ::Protobuf::Message; end

--- a/spec/support/test/deprecated.pb.rb
+++ b/spec/support/test/deprecated.pb.rb
@@ -1,0 +1,25 @@
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf/message'
+
+module Test
+
+  ##
+  # Message Classes
+  #
+  class DeprecatedMessage < ::Protobuf::Message; end
+
+
+  ##
+  # Message Fields
+  #
+  class DeprecatedMessage
+    def self.deprecated?
+      true
+    end
+
+  end
+
+end
+

--- a/spec/support/test/deprecated.proto
+++ b/spec/support/test/deprecated.proto
@@ -4,8 +4,14 @@ message DeprecatedMessage {
   option deprecated = true;
 }
 
+enum NonDeprecatedEnum {
+  A_DEPRECATED_VALUE = 1 [deprecated = true];
+  NOT_DEPRECATED_VALUE = 2;
+}
+
 enum DeprecatedEnum {
   option deprecated = true;
 
-  A_DEPRECATED_VALUE = 1 [deprecated = true];
+  EXPLICIT = 1 [deprecated = true];
+  IMPLICIT = 2;
 }

--- a/spec/support/test/deprecated.proto
+++ b/spec/support/test/deprecated.proto
@@ -1,0 +1,5 @@
+package test;
+
+message DeprecatedMessage {
+  option deprecated = true;
+}

--- a/spec/support/test/deprecated.proto
+++ b/spec/support/test/deprecated.proto
@@ -7,5 +7,5 @@ message DeprecatedMessage {
 enum DeprecatedEnum {
   option deprecated = true;
 
-  FOO = 1 [deprecated = true];
+  A_DEPRECATED_VALUE = 1 [deprecated = true];
 }

--- a/spec/support/test/deprecated.proto
+++ b/spec/support/test/deprecated.proto
@@ -3,3 +3,9 @@ package test;
 message DeprecatedMessage {
   option deprecated = true;
 }
+
+enum DeprecatedEnum {
+  option deprecated = true;
+
+  FOO = 1 [deprecated = true];
+}


### PR DESCRIPTION
Converts the following definition:

``` protobuf
package test;

enum NonDeprecatedEnum {
  A_DEPRECATED_VALUE = 1 [deprecated = true];
  NOT_DEPRECATED_VALUE = 2;
}

enum DeprecatedEnum {
  option deprecated = true;

  EXPLICIT = 1 [deprecated = true];
  IMPLICIT = 2;
}
```

... into ...

``` ruby
module Test
    class NonDeprecatedEnum < ::Protobuf::Enum
    define :A_DEPRECATED_VALUE, 1, :deprecated => true
    define :NOT_DEPRECATED_VALUE, 2      # not deprecated
  end

  class DeprecatedEnum < ::Protobuf::Enum
    def self.deprecated?
      true
    end

    define :EXPLICIT, 1, :deprecated => true
    define :IMPLICIT, 2, :deprecated => true     # automatically deprecated
  end
end
```

You can query an enum and any of its values to see if it is deprecated or not:

``` ruby
Test::NonDeprecatedEnum.deprecated? # => false
Test::DeprecatedEnum::IMPLICIT.deprecated? # => true
```

Also note that deprecating an entire enum will automatically deprecate each of its values as well.

Relates to #211, #212, and #215.
