### PR TITLE
Abrandoned/set timeout on workers avail

### DIFF
--- a/lib/protobuf/rpc/connectors/base.rb
+++ b/lib/protobuf/rpc/connectors/base.rb
@@ -17,9 +17,9 @@ module Protobuf
         :request                 => nil,         # The request object sent by the client
         :request_type            => nil,         # The request type expected by the client
         :response_type           => nil,         # The response type expected by the client
-        :timeout                 => 300,         # The default timeout for the request, also handled by client.rb
+        :timeout                 => nil,         # The timeout for the request, also handled by client.rb
         :client_host             => nil,         # The hostname or address of this client
-        :first_alive_load_balance => false,       # Do we want to use check_avail frames before request
+        :first_alive_load_balance => false,      # Do we want to use check_avail frames before request
       }
 
       class Base

--- a/lib/protobuf/rpc/connectors/common.rb
+++ b/lib/protobuf/rpc/connectors/common.rb
@@ -135,12 +135,20 @@ module Protobuf
           complete
         end
 
+        def timeout
+          if options[:timeout]
+            options[:timeout]
+          else
+            300 # seconds
+          end
+        end
+
         # Wrap the given block in a timeout of the configured number of seconds.
         #
         def timeout_wrap(&block)
-          ::Timeout.timeout(options[:timeout], &block)
+          ::Timeout.timeout(timeout, &block)
         rescue ::Timeout::Error
-          fail(:RPC_FAILED, "The server took longer than #{options[:timeout]} seconds to respond")
+          fail(:RPC_FAILED, "The server took longer than #{timeout} seconds to respond")
         end
 
         def validate_request_type!


### PR DESCRIPTION
ok, learning more about the zmq server/client pairing

this PR moves client timeout (for request/response) to the zmq layer as zmq 3 added timeout on the socket layer directly and works "better" than a poller/polling item and makes the default available to a env var

also sets a rcv timeout and snd timeout on the available workers check, without this timeout there are significant issues when an rpc is abruptly killed and holds open requests from servers (we measured that a single rpc server will swallows 100-200 avail check requests during a `kill -9`); eventually the clients will "restart" the threads that died but if the client thread count is low it will yield an unusable system.

new env vars:
`PB_ZMQ_CLIENT_CHECK_AVAILABLE_RCV_TIMEOUT` - the rcv_timeout on the check avail, can be set very low as it is only sending a single byte message and trying to find an acceptable server, defaulted to 200ms which works under heavy load without issue
`PB_ZMQ_CLIENT_CHECK_AVAILABLE_SND_TIMEOUT` - all zmq timeouts have 2 elements the receive and the send as it knows if a packet has been sent, this is the send timeout for check avail and also set to 200ms by default
`PB_ZMQ_CLIENT_RCV_TIMEOUT` - rcv timeout for the actual request from the client, this sets the default and can be overridden by each call
`PB_ZMQ_CLIENT_SND_TIMEOUT` - snd timeout for the actual request from the client, this sets the default and can be overrideen by each call

Adding these timeouts made a significant change in time to recover after a process failure or process blockage

@quixoten @localshred @liveh2o 
