### PR TITLE
Fix CLI Options bug and RPC Services bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # protobuf
 
 [![Gem Version](https://badge.fury.io/rb/protobuf.svg)](http://badge.fury.io/rb/protobuf)
-[![Build Status](https://secure.travis-ci.org/localshred/protobuf.svg?branch=master)](https://travis-ci.org/localshred/protobuf)
+[![Build Status](https://secure.travis-ci.org/ruby-protobuf/protobuf.svg?branch=master)](https://travis-ci.org/localshred/protobuf)
 [![Gitter chat](https://badges.gitter.im/localshred/protobuf.svg)](https://gitter.im/localshred/protobuf)
 [![protobuf API Documentation](https://www.omniref.com/ruby/gems/protobuf.png)](https://www.omniref.com/ruby/gems/protobuf)
 

--- a/lib/protobuf/cli.rb
+++ b/lib/protobuf/cli.rb
@@ -182,7 +182,7 @@ module Protobuf
       end
 
       def runner_options
-        opt = options.symbolize_keys
+        opt = options.to_hash
 
         opt[:workers_only] = (!!ENV['PB_WORKERS_ONLY']) || options.workers_only
 

--- a/lib/protobuf/cli.rb
+++ b/lib/protobuf/cli.rb
@@ -182,7 +182,7 @@ module Protobuf
       end
 
       def runner_options
-        opt = options.to_hash
+        opt = options.to_hash.symbolize_keys
 
         opt[:workers_only] = (!!ENV['PB_WORKERS_ONLY']) || options.workers_only
 

--- a/lib/protobuf/rpc/servers/socket_runner.rb
+++ b/lib/protobuf/rpc/servers/socket_runner.rb
@@ -12,10 +12,8 @@ module Protobuf
         options = case
                    when options.is_a?(OpenStruct) then
                      options.marshal_dump
-                   when options.is_a?(Hash) then
-                     options
                    when options.respond_to?(:to_hash) then
-                     options.to_hash
+                     options.to_hash.symbolize_keys
                    else
                      fail "Cannot parser Socket Server - server options"
                    end

--- a/lib/protobuf/rpc/servers/zmq_runner.rb
+++ b/lib/protobuf/rpc/servers/zmq_runner.rb
@@ -11,7 +11,7 @@ module Protobuf
                    when options.is_a?(OpenStruct) then
                      options.marshal_dump
                    when options.respond_to?(:to_hash) then
-                     options.to_hash
+                     options.to_hash.symbolize_keys
                    else
                      fail "Cannot parser Zmq Server - server options"
                    end

--- a/lib/protobuf/rpc/service.rb
+++ b/lib/protobuf/rpc/service.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/class'
+
 require 'protobuf/logging'
 require 'protobuf/rpc/client'
 require 'protobuf/rpc/error'

--- a/spec/functional/zmq_server_spec.rb
+++ b/spec/functional/zmq_server_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe 'Functional ZMQ Client' do
   before(:all) do
     load "protobuf/zmq.rb"
     @runner = ::Protobuf::Rpc::ZmqRunner.new(
-      :host => "127.0.0.1",
-      :port => 9399,
-      :worker_port => 9408,
-      :backlog => 100,
-      :threshold => 100,
-      :threads => 5,
+      'host' => '127.0.0.1',
+      'port' => 9399,
+      'worker_port' => 9408,
+      'backlog' => 100,
+      'threshold' => 100,
+      'threads' => 5,
     )
     @server_thread = Thread.new(@runner) { |runner| runner.run }
     Thread.pass until @runner.running?


### PR DESCRIPTION
Thor's `HashWithIndifferentAccess` doesn't implement `symbolize_keys`, and recently became an issue because the keys would remain strings, instead of being converted into symbols. So, this makes sure we call `to_hash` before we call `symbolize_keys`. To be safe, I added the same `to_hash.symbolize_keys` to the constructors of `ZmqRunner` as well as `SocketRunner`. I also updated the functional zmq_server_spec to make sure everything is :ok_hand: .

Another small bug was our usage of `subclasses` in `Rpc::Service`. When loading rpc_server with rails, everything works fine, because the entire active_support gem is loaded. But if you load an environment file that doesn't load active_support, you'll get a method not found error. To fix this, I explicitly require `active_support/core_ext/class` and everything is :ok_hand: .

One last thing. The link to travis in the README is broken. This corrects that too.