### PR TITLE
Thread can be sleeping under MRI, fix by using `alive?`

### DIFF
--- a/lib/protobuf/rpc/servers/zmq/server.rb
+++ b/lib/protobuf/rpc/servers/zmq/server.rb
@@ -284,7 +284,7 @@ module Protobuf
         end
 
         def start_broker
-          return if @broker && @broker.running? && !@broker_thread.stop?
+          return if @broker && @broker.running? && @broker_thread.alive?
           if @broker && !@broker.running?
             broadcast_flatline if broadcast_busy?
             @broker_thread.join if @broker_thread


### PR DESCRIPTION
For some reason, the broker thread will be sleeping under MRI and therefore will fail the `!@broker_thread.stop?` condition. Switching to `@broker_thread.alive?` fixes this and allows protobuf to function normally.