### PR TITLE
Optimized get_extension_field and get_field calls

### DIFF
--- a/lib/protobuf/message/fields.rb
+++ b/lib/protobuf/message/fields.rb
@@ -78,14 +78,12 @@ module Protobuf
         end
 
         def get_extension_field(name_or_tag)
-          name_or_tag = name_or_tag.to_sym if name_or_tag.respond_to?(:to_sym)
-          field = field_store[name_or_tag]
+          field = field_store[name_or_tag] || str_field_store[name_or_tag]
           field if field.try(:extension?) { false }
         end
 
         def get_field(name_or_tag, allow_extension = false)
-          name_or_tag = name_or_tag.to_sym if name_or_tag.respond_to?(:to_sym)
-          field = field_store[name_or_tag]
+          field = field_store[name_or_tag] || str_field_store[name_or_tag]
 
           if field && (allow_extension || !field.extension?)
             field
@@ -101,6 +99,8 @@ module Protobuf
           field = ::Protobuf::Field.build(self, rule, type_class, field_name, tag, options)
           field_store[field_name] = field
           field_store[tag] = field
+
+          str_field_store[field_name.to_s] = field
 
           define_method("#{field_name}!") do
             @values[field_name]
@@ -126,6 +126,10 @@ module Protobuf
         end
         private :inherit_fields!
 
+        def str_field_store
+          @str_field_store ||= {}
+        end
+        private :str_field_store
       end
     end
   end


### PR DESCRIPTION
This trace on calls besides `respond_to?`/`get_field` aren't quite accurate as the other traces I had also included a varint optimization I'll submit an issue for if you are interested. It's still good for the optimization I'm showing in the PR.

Started with a trace of (after the enum optimization):

```
Measure Mode: wall_time
Thread ID: 70126242488840
Fiber ID: 70126246561280
Total: 2.722766
Sort by: self_time

 %self      total      self      wait     child     calls  name
  5.65      0.676     0.154     0.000     0.522    72000   <Class::Protobuf::Decoder>#read_field
  5.64      0.172     0.154     0.000     0.018    94000   Kernel#respond_to?
  4.55      0.283     0.124     0.000     0.159    72000   <Class::Protobuf::Decoder>#read_key
  4.04      0.302     0.110     0.000     0.192    72000   Protobuf::Message::Fields::ClassMethods#get_field
  3.48      0.250     0.095     0.000     0.156   140000   <Class::Protobuf::Decoder>#read_varint
  3.13      0.156     0.085     0.000     0.070   140000   Varint#decode
  2.86      0.078     0.078     0.000     0.000   144000   Protobuf::Field::BaseField#repeated?
  2.58      0.070     0.070     0.000     0.000   166500   StringIO#getbyte
  2.49      0.068     0.068     0.000     0.000    69000   Protobuf::Field::BaseField#setter
  2.10      0.058     0.057     0.000     0.000     1500   Kernel#caller
```

For our test cases, we saw about 2,000 calls to `get_field` requiring a call to `to_sym`, which means we're doing 72,000 `respond_to?` calls to run `to_sym` 2,000 times.

Rather than casting to `to_sym` each time, which can potentially cause symbol leaks (if people aren't on MRI 2.2), we can store a lookup of the string field to field, on top of our symbol to field.

This optimization brings it down to

```
Measure Mode: wall_time
Thread ID: 70107917574660
Fiber ID: 70107924939720
Total: 2.428846
Sort by: self_time

 %self      total      self      wait     child     calls  name
  6.12      0.666     0.155     0.000     0.511    72000   <Class::Protobuf::Decoder>#read_field
  4.70      0.277     0.119     0.000     0.158    72000   <Class::Protobuf::Decoder>#read_key
  3.70      0.248     0.094     0.000     0.154   140000   <Class::Protobuf::Decoder>#read_varint
  3.39      0.132     0.086     0.000     0.046    72000   Protobuf::Message::Fields::ClassMethods#get_field
  3.39      0.154     0.086     0.000     0.068   140000   Varint#decode
  2.96      0.075     0.075     0.000     0.000   144000   Protobuf::Field::BaseField#repeated?
  2.70      0.068     0.068     0.000     0.000   166500   StringIO#getbyte
  2.60      0.066     0.066     0.000     0.000    69000   Protobuf::Field::BaseField#setter
```

Which is about a 12% improvement. I put the `str_field_store` check after the `field_store` because more often we lookup by symbol/int. The reason I put this as a separate hash, was to reduce the chance of breaking things. It wasn't entirely clear if other people rely on `field_store` for iterating since the method is public.
