### PR TITLE
Varint optimizations

### DIFF
--- a/lib/protobuf/decoder.rb
+++ b/lib/protobuf/decoder.rb
@@ -16,7 +16,7 @@ module Protobuf
       tag, wire_type = read_key(stream)
       bytes = case wire_type
               when ::Protobuf::WireType::VARINT then
-                read_varint(stream)
+                Varint.decode(stream)
               when ::Protobuf::WireType::FIXED64 then
                 read_fixed64(stream)
               when ::Protobuf::WireType::LENGTH_DELIMITED then
@@ -60,14 +60,7 @@ module Protobuf
 
     # Read varint integer value from +stream+.
     def self.read_varint(stream)
-      value = index = 0
-      begin
-        byte = stream.readbyte
-        value |= (byte & 0x7f) << (7 * index)
-        index += 1
-      end while (byte & 0x80).nonzero?
-      value
+      Varint.decode(stream)
     end
-
   end
 end

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -4,6 +4,17 @@ require 'protobuf/exceptions'
 require 'protobuf/message/fields'
 require 'protobuf/message/serialization'
 
+# Under MRI, this optimizes proto decoding by around 15% in tests.
+# When unavailable, we fall to pure Ruby.
+# rubocop:disable Lint/HandleExceptions
+begin
+  require 'varint/varint'
+rescue LoadError
+end
+# rubocop:enable Lint/HandleExceptions
+
+require 'protobuf/varint'
+
 module Protobuf
   class Message
 

--- a/lib/protobuf/varint.rb
+++ b/lib/protobuf/varint.rb
@@ -1,0 +1,11 @@
+require 'protobuf/varint_pure'
+
+module Protobuf
+  class Varint
+    if defined?(::Varint)
+      extend ::Varint
+    else
+      extend VarintPure
+    end
+  end
+end

--- a/lib/protobuf/varint_pure.rb
+++ b/lib/protobuf/varint_pure.rb
@@ -1,0 +1,13 @@
+module Protobuf
+  module VarintPure
+    def decode(stream)
+      value = index = 0
+      begin
+        byte = stream.readbyte
+        value |= (byte & 0x7f) << (7 * index)
+        index += 1
+      end while (byte & 0x80).nonzero?
+      value
+    end
+  end
+end

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -43,9 +43,10 @@ require "protobuf/version"
 
     s.add_development_dependency pry_debugger
     s.add_development_dependency 'pry-stack_explorer'
+
+    s.add_development_dependency 'varint'
+    s.add_development_dependency 'ruby-prof'
   else
     s.add_development_dependency 'pry'
   end
-
-  s.add_development_dependency 'ruby-prof' if RUBY_ENGINE.to_sym == :ruby
 end

--- a/spec/lib/protobuf/varint_spec.rb
+++ b/spec/lib/protobuf/varint_spec.rb
@@ -1,0 +1,29 @@
+require 'base64'
+require 'spec_helper'
+
+RSpec.describe Protobuf::Varint do
+  VALUES = {
+    0 => "AA==",
+    5 => "BQ==",
+    51 => "Mw==",
+    9_192 => "6Ec=",
+    80_389 => "hfQE",
+    913_389 => "7d83",
+    516_192_829_912_693 => "9eyMkpivdQ==",
+    9_999_999_999_999_999_999 => "//+fz8jgyOOKAQ==",
+  }
+
+  [defined?(::Varint) ? ::Varint : nil, Protobuf::VarintPure].compact.each do |klass|
+    context "with #{klass}" do
+      before { described_class.extend(klass) }
+      after { load ::File.expand_path('../../../../lib/protobuf/varint.rb', __FILE__) }
+
+      VALUES.each do |number, encoded|
+        it "decodes #{number}" do
+          io = StringIO.new(Base64.decode64(encoded))
+          expect(described_class.decode(io)).to eq(number)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Per #268, here's the results of benchmarking C vs pure Ruby. For the sake of being thorough, I also tested the variant used in the other protobuf gem (which was related to what @jjowdy) suggested, and it performed worst.

```
       user     system      total        real
pure_protobuf  1.080000   0.010000   1.090000 (  1.087074)
pure_alt  1.260000   0.010000   1.270000 (  1.275954)
c  0.700000   0.000000   0.700000 (  0.708581)
```

I also tested the C encoder in the varint gem, and it appears to be slower. This might be because with how protobuf is implemented, we need to create a `StringIO` class, rewind it, and then call `read` in order to get. Rewriting things might speed it up, but that's outside of what I'm looking to do in this PR.

Thanks @hollow and @codekitchen for the extension!