### PR TITLE
Improve assignment to array

### DIFF
--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -194,6 +194,11 @@ module Protobuf
 
         message_class.class_eval do
           define_method(method_name) do |val|
+            if val.nil? || (val.respond_to?(:empty?) && val.empty?)
+              @values.delete(field.name)
+              return
+            end
+
             if val.is_a?(Array)
               val = val.dup
               val.compact!
@@ -204,12 +209,8 @@ module Protobuf
               TYPE_ERROR
             end
 
-            if val.nil? || (val.respond_to?(:empty?) && val.empty?)
-              @values.delete(field.name)
-            else
-              @values[field.name] ||= ::Protobuf::Field::FieldArray.new(field)
-              @values[field.name].replace(val)
-            end
+            @values[field.name] ||= ::Protobuf::Field::FieldArray.new(field)
+            @values[field.name].replace(val)
           end
         end
 

--- a/lib/protobuf/field/field_array.rb
+++ b/lib/protobuf/field/field_array.rb
@@ -71,7 +71,7 @@ module Protobuf
         elsif field.is_a?(::Protobuf::Field::MessageField) && value.respond_to?(:to_hash)
           field.type_class.new(value.to_hash)
         else
-          value
+          field.coerce!(value)
         end
       end
 

--- a/spec/functional/assignment_spec.rb
+++ b/spec/functional/assignment_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'spec/support/test/resource_service'
+
+RSpec.describe 'assign' do
+  class Foo < ::Protobuf::Message
+    repeated :string, :string, 1
+    repeated :float, :float, 2
+    repeated :double, :double, 3
+    repeated :int32, :int32, 4
+    repeated :int64, :int64, 5
+  end
+
+  let(:target) { Foo.new }
+
+  specify 'string to repeated string' do
+    target.string = ["foo1", "foo2"]
+    expect(target.string).to eq(["foo1", "foo2"])
+  end
+
+  specify 'string to repeated int32' do
+    target.int32 = ["1", "-1"]
+    expect(target.int32).to eq([1, -1])
+  end
+
+  specify 'string to repeated int64' do
+    target.int64 = [String(2**41), String(-2**41)]
+    expect(target.int64).to eq([2**41, -2**41])
+  end
+
+  specify 'string to repeated float' do
+    target.float = ["1.1", "-1.1"]
+    expect(target.float).to eq([1.1, -1.1])
+  end
+
+  specify 'string to repeated double' do
+    target.double = ["1.1", "-1.1"]
+    expect(target.double).to eq([1.1, -1.1])
+  end
+
+  specify 'nil to repeated string' do
+    target.string = ["foo1", "foo2"]
+    target.string = nil
+    expect(target.string).to eq([])
+  end
+
+  specify 'nil to repeated int32' do
+    target.int32 = ["1", "2"]
+    target.int32 = nil
+    expect(target.int32).to eq([])
+  end
+
+  specify 'nil to repeated int64' do
+    target.int64 = [String(1**40), String(1**41)]
+    target.int64 = nil
+    expect(target.int64).to eq([])
+  end
+
+  specify 'nil to repeated float' do
+    target.float = ["1.1", "1.2"]
+    target.float = nil
+    expect(target.float).to eq([])
+  end
+
+  specify 'nil to repeated double' do
+    target.double = ["1.1", "1.2"]
+    target.double = nil
+    expect(target.double).to eq([])
+  end
+end


### PR DESCRIPTION
1. Orignally checking for is_a?(Array) is before nil?, so when assigning
nil to an repeated value, TypeError will be raised, and the nil? part
will never be reached. This is rather undesirable I think.

2. Call field.coerce! when assigning to repeated value, to keep
consistent with assigning to non-repeated value.