### PR TITLE
forcing import requires to work

### DIFF
--- a/lib/protobuf/generators/file_generator.rb
+++ b/lib/protobuf/generators/file_generator.rb
@@ -107,7 +107,8 @@ module Protobuf
         header "Imports"
 
         descriptor.dependency.each do |dependency|
-          print_require(convert_filename(dependency))
+          #print_require(convert_filename(dependency))
+          puts "'require_relative #{convert_filename(dependency)}'"
         end
 
         puts
@@ -122,7 +123,7 @@ module Protobuf
 
       private
 
-      def convert_filename(filename, for_require = true)
+      def convert_filename(filename, for_require = false)
         filename.sub(/\.proto/, (for_require ? '.pb' : '.pb.rb'))
       end
 


### PR DESCRIPTION
Using `protoc -I ./definitions --ruby_out ./lib/picatrix/generated definitions/*.proto` to generate my Ruby files, where on `.proto` file is importing another. Unless I make these changes, the generated code will have `require 'mason.pb'` which won't work. Should I be arranging my proto files differently to avoid this, or should some additional code be added to allow relative requiring?