### PR TITLE
Ensure the ping port is timed out after a reasonable amount of time

### DIFF
--- a/lib/protobuf/rpc/connectors/ping.rb
+++ b/lib/protobuf/rpc/connectors/ping.rb
@@ -1,0 +1,87 @@
+require "socket"
+
+module Protobuf
+  module Rpc
+    module Connectors
+      class Ping
+        attr_reader :host, :port
+
+        def initialize(host, port)
+          @host = host
+          @port = port
+        end
+
+        def online?
+          socket = tcp_socket
+          socket.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_LINGER, [1, 0].pack('ii'))
+
+          true
+        rescue
+          false
+        ensure
+          begin
+            socket && socket.close
+          rescue IOError
+            nil
+          end
+        end
+
+        def timeout
+          @timeout ||= begin
+            if ::ENV.key?("PB_RPC_PING_PORT_TIMEOUT")
+              ::ENV["PB_RPC_PING_PORT_TIMEOUT"].to_i
+            else
+              5 # 5 seconds
+            end
+          end
+        end
+
+        private
+
+        def tcp_socket
+          # Reference: http://stackoverflow.com/a/21014439/1457934
+          socket = ::Socket.new(family, ::Socket::SOCK_STREAM, 0)
+          socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+          socket.connect_nonblock(sockaddr)
+        rescue ::IO::WaitWritable
+          # IO.select will block until the socket is writable or the timeout
+          # is exceeded - whichever comes first.
+          if ::IO.select(nil, [socket], nil, timeout)
+            begin
+              # Verify there is now a good connection
+              socket.connect_nonblock(sockaddr)
+            rescue ::Errno::EISCONN
+              # Socket is connected.
+              socket
+            rescue
+              # An unexpected exception was raised - the connection is no good.
+              socket.close
+              raise
+            end
+          else
+            # IO.select returns nil when the socket is not ready before timeout
+            # seconds have elapsed
+            socket.close
+            raise "Connection Timeout"
+          end
+        end
+
+        def family
+          @family ||= ::Socket.const_get(addrinfo[0][0])
+        end
+
+        def addrinfo
+          @addrinfo ||= ::Socket.getaddrinfo(host, nil)
+        end
+
+        def ip
+          @ip ||= addrinfo[0][3]
+        end
+
+        def sockaddr
+          @sockaddr ||= ::Socket.pack_sockaddr_in(port, ip)
+        end
+      end
+    end
+  end
+end

--- a/lib/protobuf/rpc/connectors/zmq.rb
+++ b/lib/protobuf/rpc/connectors/zmq.rb
@@ -1,6 +1,7 @@
-require 'thread_safe'
-require 'protobuf/rpc/connectors/base'
-require 'protobuf/rpc/service_directory'
+require "thread_safe"
+require "protobuf/rpc/connectors/base"
+require "protobuf/rpc/connectors/ping"
+require "protobuf/rpc/service_directory"
 
 module Protobuf
   module Rpc
@@ -161,19 +162,7 @@ module Protobuf
         end
 
         def ping_port_open?(host)
-          socket = TCPSocket.new(host, ping_port.to_i)
-          socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
-          socket.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_LINGER, [1, 0].pack('ii'))
-
-          true
-        rescue
-          false
-        ensure
-          begin
-            socket && socket.close
-          rescue IOError
-            nil
-          end
+          Ping.new(host, ping_port.to_i).online?
         end
 
         def rcv_timeout

--- a/spec/lib/protobuf/rpc/connectors/ping_spec.rb
+++ b/spec/lib/protobuf/rpc/connectors/ping_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+require "protobuf/zmq"
+
+::RSpec.describe ::Protobuf::Rpc::Connectors::Ping do
+  subject { described_class.new("google.com", 80) }
+
+  let(:host) { "google.com" }
+  let(:port) { 80 }
+
+  describe ".new" do
+    it "assigns host" do
+      expect(subject.host).to eq(host)
+    end
+
+    it "assigns port" do
+      expect(subject.port).to eq(port)
+    end
+  end
+
+  describe "#online?" do
+    it "closes the socket" do
+      socket = double(:close => nil, :setsockopt => nil)
+      allow(subject).to receive(:tcp_socket).and_return(socket)
+      expect(socket).to receive(:close)
+      expect(subject).to be_online
+    end
+
+    context "when a socket can connect" do
+      let(:socket) { double(:close => nil, :setsockopt => nil) }
+      before { allow(subject).to receive(:tcp_socket).and_return(socket) }
+
+      it "returns true" do
+        expect(subject).to be_online
+      end
+    end
+
+    context "when a socket error is raised" do
+      before { allow(subject).to receive(:tcp_socket).and_raise(::Errno::ECONNREFUSED) }
+
+      it "returns false" do
+        expect(subject).to_not be_online
+      end
+    end
+
+    context "when a select timeout is fired" do
+      let(:wait_writable_class) { ::Class.new(StandardError) { include ::IO::WaitWritable } }
+      before { expect_any_instance_of(::Socket).to receive(:connect_nonblock).and_raise(wait_writable_class) }
+
+      it "returns false" do
+        expect(::IO).to receive(:select).and_return(false)
+        expect(subject).to_not be_online
+      end
+    end
+  end
+
+  describe "#timeout" do
+    it "uses the default value" do
+      expect(subject.timeout).to eq(5)
+    end
+
+    context "when environment variable is set" do
+      before { ::ENV["PB_RPC_PING_PORT_TIMEOUT"] = "1" }
+
+      it "uses the environmet variable" do
+        expect(subject.timeout).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/lib/protobuf/rpc/connectors/zmq_spec.rb
+++ b/spec/lib/protobuf/rpc/connectors/zmq_spec.rb
@@ -93,24 +93,17 @@ RSpec.describe ::Protobuf::Rpc::Connectors::Zmq do
 
     context "when the PB_RPC_PING_PORT is set" do
       before do
-        ENV["PB_RPC_PING_PORT"] = "3307"
+        ::ENV["PB_RPC_PING_PORT"] = "3307"
       end
 
       it "returns true when the connection succeeds" do
-        expect(TCPSocket).to receive(:new).with("huzzah.com", 3307).and_return(double(:close => nil, :setsockopt => nil))
-        expect(subject.send(:host_alive?, "huzzah.com")).to be true
+        allow_any_instance_of(::Protobuf::Rpc::Connectors::Ping).to receive(:online?).and_return(true)
+        expect(subject.send(:host_alive?, "huzzah1.com")).to eq(true)
       end
 
       it "returns false when the connection fails" do
-        expect(TCPSocket).to receive(:new).with("hayoob.com", 3307).and_raise(Errno::ECONNREFUSED)
-        expect(subject.send(:host_alive?, "hayoob.com")).to be false
-      end
-
-      it "closes the socket" do
-        socket = double("TCPSocket", :setsockopt => nil)
-        expect(socket).to receive(:close)
-        expect(TCPSocket).to receive(:new).with("absorbalof.com", 3307).and_return(socket)
-        expect(subject.send(:host_alive?, "absorbalof.com")).to be true
+        allow_any_instance_of(::Protobuf::Rpc::Connectors::Ping).to receive(:online?).and_return(false)
+        expect(subject.send(:host_alive?, "huzzah2.com")).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Should a server's ping port get jammed, overwhelmed, or access a port that is not open, then the ping port check will block until the TCPSocket default timeout rescues the blocked request. Instead, we can wrap Socket to add a reasonable timeout to ping port checks. By default, the timeout is set to 5 seconds, but you can customize this by setting the `PB_RPC_PING_PORT_TIMEOUT` environment variable.

There is probably some more work that can be done here, but I wanted this PR to be about solving this ping port problem before I make a few more changes, like using `PB_RPC_PING_PORT` inside of the new `Ping` class.

cc @abrandoned @quixoten @mmmries @liveh2o @brianstien @localshred 