### PR TITLE
Ensure bundler is at the latest version to make travis pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libzmq3-dev
   - sudo -E ./install-protobuf.sh
+  - gem update bundler
 language: ruby
 rvm:
   - 1.9.3

--- a/spec/lib/protobuf_spec.rb
+++ b/spec/lib/protobuf_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ::Protobuf do
     subject { ::Protobuf.client_host }
 
     context 'when client_host is not pre-configured' do
-      it { is_expected.to eq `hostname`.chomp }
+      it { is_expected.to eq ::Socket.gethostname }
     end
 
     context 'when client_host is pre-configured' do


### PR DESCRIPTION
Other github projects have seen the failing bundler issue and this is how they fixed it:

pdfkit/pdfkit#347
increments/qiita-markdown#24

Thanks @RKushnir for figuring it out.

cc @mmmries @brianstien @abrandoned @localshred 