### PR TITLE
[NEW FEATURE] add PB_ENUM_UPCASE option

### DIFF
--- a/lib/protobuf/generators/enum_generator.rb
+++ b/lib/protobuf/generators/enum_generator.rb
@@ -32,6 +32,7 @@ module Protobuf
 
       def build_value(enum_value_descriptor)
         name = enum_value_descriptor.name
+        name.upcase! if ENV.key?('PB_UPCASE_ENUMS')
         number = enum_value_descriptor.number
         "define :#{name}, #{number}"
       end

--- a/spec/lib/protobuf/generators/enum_generator_spec.rb
+++ b/spec/lib/protobuf/generators/enum_generator_spec.rb
@@ -68,6 +68,15 @@ end
     it 'returns a string identifying the given enum value' do
       expect(subject.build_value(enum.value.first)).to eq("define :FOO, 1")
     end
+
+    context 'with PB_UPCASE_ENUMS set' do
+      before { allow(ENV).to receive(:key?).with('PB_UPCASE_ENUMS').and_return(true) }
+      let(:values) { [{ :name => 'boom', :number => 1 }] }
+
+      it 'returns a string with the given enum name in ALL CAPS' do
+        expect(subject.build_value(enum.value.first)).to eq("define :BOOM, 1")
+      end
+    end
   end
 
 end


### PR DESCRIPTION
enum names are not required to be Capitalized, but ruby constants are.
Add option to UPCASE all enum names

This proto definition:

```
enum SillyEnum {
  foo = 1;
  BAR = 2;
  BAZ = 3;
}
```

Generates this code:

```
class SillyEnum < ::Protobuf::Enum
  define :foo, 1
  define :BAR, 2
  define :BAZ, 3
end
```

I get this error loading the generated code:

```
% pry -I. -r protobuf/deprecation -r silly_enum.pb
.../lib/protobuf/enum.rb:58:in `const_set': wrong constant name foo (NameError)
	from .../lib/protobuf/enum.rb:58:in `define'
```

Enabling `PB_ENUM_UPCASE` changes the generated code to:


```
class SillyEnum < ::Protobuf::Enum
  define :FOO, 1
  define :BAR, 2
  define :BAZ, 3
end
```