### PR TITLE
only fetch value once on serialization and cache the varint encoding …

### DIFF
--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -81,15 +81,11 @@ module Protobuf
 
     def each_field_for_serialization
       self.class.all_fields.each do |field|
-        next unless field_must_be_serialized?(field)
-
         value = @values[field.getter]
+        fail ::Protobuf::SerializationError, "Required field #{self.class.name}##{field.name} does not have a value." if value.nil? && field.required?
+        next if value.nil?
 
-        if value.nil?
-          fail ::Protobuf::SerializationError, "Required field #{self.class.name}##{field.name} does not have a value."
-        else
-          yield(field, value)
-        end
+        yield(field, value)
       end
     end
 

--- a/lib/protobuf/message/serialization.rb
+++ b/lib/protobuf/message/serialization.rb
@@ -75,10 +75,6 @@ module Protobuf
 
       private
 
-      def field_must_be_serialized?(field)
-        field.required? || ! @values[field.name].nil?
-      end
-
       def set_field_bytes(tag, bytes)
         field = self.class.get_field(tag, true)
         field.set(self, bytes) if field


### PR DESCRIPTION
…for most common cases (< 1024)

adding a cache of varint fields for any varint < 1024 for now (may make configurable in the future), runs it on load and uses the cached values instead of calculating

https://gist.github.com/abrandoned/044cf200037ff7885572

about 100% increase in encoding time of varints under jruby when varint is > 128; < 128 10%

