### PR TITLE
rubocop: exclude generated proto code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,10 @@ Style/ClassAndModuleChildren:
   Exclude:
     - '**/*.pb.rb'
 
+Style/ClassAndModuleCamelCase:
+  Exclude:
+    - '**/*.pb.rb'
+
 Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 


### PR DESCRIPTION
This should fix the failing specs