### PR TITLE
Allow snake_case module and class naming in generated proto files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ Metrics/ModuleLength:
 Style/CaseIndentation:
   IndentWhenRelativeTo: end
 
+Style/ClassAndModuleCamelCase:
+  Exclude:
+    - '**/*.pb.rb'
+
 Style/ClassAndModuleChildren:
   Exclude:
     - '**/*.pb.rb'


### PR DESCRIPTION
Resolves the following:
```
Offenses:

spec/support/protos/google_unittest.pb.rb:15:8: C: Use CamelCase for classes and modules.
module Protobuf_unittest
       ^^^^^^^^^^^^^^^^^
spec/support/protos/google_unittest.pb.rb:69:9: C: Use CamelCase for classes and modules.
  class OptionalGroup_extension < ::Protobuf::Message; end
        ^^^^^^^^^^^^^^^^^^^^^^^
spec/support/protos/google_unittest.pb.rb:70:9: C: Use CamelCase for classes and modules.
  class RepeatedGroup_extension < ::Protobuf::Message; end
        ^^^^^^^^^^^^^^^^^^^^^^^
spec/support/protos/google_unittest.pb.rb:367:9: C: Use CamelCase for classes and modules.
  class OptionalGroup_extension
        ^^^^^^^^^^^^^^^^^^^^^^^
spec/support/protos/google_unittest.pb.rb:371:9: C: Use CamelCase for classes and modules.
  class RepeatedGroup_extension
        ^^^^^^^^^^^^^^^^^^^^^^^
spec/support/protos/google_unittest_import.pb.rb:14:8: C: Use CamelCase for classes and modules.
module Protobuf_unittest_import
       ^^^^^^^^^^^^^^^^^^^^^^^^
spec/support/protos/google_unittest_import_public.pb.rb:8:8: C: Use CamelCase for classes and modules.
module Protobuf_unittest_import
       ^^^^^^^^^^^^^^^^^^^^^^^^
```

cc @abrandoned @mmmries @liveh2o @brianstien 