### PR TITLE
Abrandoned/serialization encoding optimizations

### DIFF
--- a/lib/protobuf/decoder.rb
+++ b/lib/protobuf/decoder.rb
@@ -15,17 +15,17 @@ module Protobuf
     def self.read_field(stream)
       tag, wire_type = read_key(stream)
       bytes = case wire_type
-              when ::Protobuf::WireType::VARINT then
+              when ::Protobuf::WireType::VARINT
                 Varint.decode(stream)
-              when ::Protobuf::WireType::FIXED64 then
+              when ::Protobuf::WireType::FIXED64
                 read_fixed64(stream)
-              when ::Protobuf::WireType::LENGTH_DELIMITED then
+              when ::Protobuf::WireType::LENGTH_DELIMITED
                 read_length_delimited(stream)
-              when ::Protobuf::WireType::FIXED32 then
+              when ::Protobuf::WireType::FIXED32
                 read_fixed32(stream)
-              when ::Protobuf::WireType::START_GROUP then
+              when ::Protobuf::WireType::START_GROUP
                 fail NotImplementedError, 'Group is deprecated.'
-              when ::Protobuf::WireType::END_GROUP then
+              when ::Protobuf::WireType::END_GROUP
                 fail NotImplementedError, 'Group is deprecated.'
               else
                 fail InvalidWireType, wire_type

--- a/lib/protobuf/encoder.rb
+++ b/lib/protobuf/encoder.rb
@@ -12,7 +12,7 @@ module Protobuf
           else
             value.each do |val|
               key = (field.tag << 3) | field.wire_type
-              stream << "#{::Protobuf::Field::VarintField.encode(key)}#{field.encode(value)}"
+              stream << "#{::Protobuf::Field::VarintField.encode(key)}#{field.encode(val)}"
             end
           end
         else

--- a/lib/protobuf/encoder.rb
+++ b/lib/protobuf/encoder.rb
@@ -1,67 +1,27 @@
 module Protobuf
   class Encoder
-
-    def self.encode(stream, message)
-      new(stream, message).encode
-    end
-
-    private
-
-    attr_writer :message, :stream
-
-    public
-
-    attr_reader :message, :stream
-
-    def initialize(message, stream)
-      unless message.respond_to?(:each_field_for_serialization)
-        fail ArgumentError, "Message instance must respond to :each_field_for_serialization"
-      end
-
-      self.message = message
-      self.stream = stream
-    end
-
-    def encode
+    def self.encode(message, stream)
       message.each_field_for_serialization do |field, value|
-        encode_field(field, value)
+        if field.repeated?
+          if field.packed?
+            key = (field.tag << 3) | ::Protobuf::WireType::LENGTH_DELIMITED
+            packed_value = value.map { |val| field.encode(val) }.join
+            stream << ::Protobuf::Field::VarintField.encode(key)
+            stream << ::Protobuf::Field::VarintField.encode(packed_value.size)
+            stream << packed_value
+          else
+            value.each do |val|
+              key = (field.tag << 3) | field.wire_type
+              stream << "#{::Protobuf::Field::VarintField.encode(key)}#{field.encode(value)}"
+            end
+          end
+        else
+          key = (field.tag << 3) | field.wire_type
+          stream << "#{::Protobuf::Field::VarintField.encode(key)}#{field.encode(value)}"
+        end
       end
 
       stream
     end
-
-    private
-
-    def encode_field(field, value)
-      if field.repeated?
-        encode_repeated_field(field, value)
-      else
-        write_pair(field, value)
-      end
-    end
-
-    def encode_packed_field(field, value)
-      key = (field.tag << 3) | ::Protobuf::WireType::LENGTH_DELIMITED
-      packed_value = value.map { |val| field.encode(val) }.join
-      stream << ::Protobuf::Field::VarintField.encode(key)
-      stream << ::Protobuf::Field::VarintField.encode(packed_value.size)
-      stream << packed_value
-    end
-
-    def encode_repeated_field(field, value)
-      if field.packed?
-        encode_packed_field(field, value)
-      else
-        value.each { |val| write_pair(field, val) }
-      end
-    end
-
-    # Encode key and value, and write to +stream+.
-    def write_pair(field, value)
-      key = (field.tag << 3) | field.wire_type
-      stream << ::Protobuf::Field::VarintField.encode(key)
-      stream << field.encode(value)
-    end
-
   end
 end

--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -131,8 +131,7 @@ module Protobuf
     #   Enums, the first enum defined will be returned.
     #
     def self.enum_for_tag(tag)
-      value = mapped_enums[tag.to_i]
-      value ? value.first : nil
+      (mapped_enums[tag.to_i] || []).first
     end
 
     # Public: Get an Enum by a variety of type-checking mechanisms.
@@ -157,11 +156,11 @@ module Protobuf
     #
     def self.fetch(candidate)
       case candidate
-      when self then
+      when self
         candidate
-      when ::Numeric then
+      when ::Numeric
         enum_for_tag(candidate.to_i)
-      when ::String, ::Symbol then
+      when ::String, ::Symbol
         enum_for_name(candidate)
       else
         nil
@@ -280,9 +279,9 @@ module Protobuf
 
     def to_s(format = :tag)
       case format
-      when :tag then
+      when :tag
         to_i.to_s
-      when :name then
+      when :name
         name.to_s
       else
         to_i.to_s

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -223,7 +223,7 @@ module Protobuf
 
         message_class.class_eval do
           define_method(method_name) do
-            @values.fetch(field.name, field.default_value)
+            @values[field.name] || field.default_value
           end
         end
 

--- a/lib/protobuf/field/bool_field.rb
+++ b/lib/protobuf/field/bool_field.rb
@@ -3,6 +3,8 @@ require 'protobuf/field/varint_field'
 module Protobuf
   module Field
     class BoolField < VarintField
+      FALSE_STRING = "false".freeze
+      TRUE_STRING = "true".freeze
 
       ##
       # Class Methods
@@ -23,9 +25,9 @@ module Protobuf
       def coerce!(val)
         case val
         when String then
-          if val == 'true'
+          if val == TRUE_STRING
             true
-          elsif val == 'false'
+          else # acceptable? is called before coerce, so we don't need to check for now
             false
           end
         else

--- a/lib/protobuf/field/bool_field.rb
+++ b/lib/protobuf/field/bool_field.rb
@@ -21,10 +21,13 @@ module Protobuf
       end
 
       def coerce!(val)
-        if val == 'true'
-          true
-        elsif val == 'false'
-          false
+        case val
+        when String then
+          if val == 'true'
+            true
+          elsif val == 'false'
+            false
+          end
         else
           val
         end

--- a/lib/protobuf/field/bool_field.rb
+++ b/lib/protobuf/field/bool_field.rb
@@ -24,12 +24,8 @@ module Protobuf
 
       def coerce!(val)
         case val
-        when String then
-          if val == TRUE_STRING
-            true
-          else # acceptable? is called before coerce, so we don't need to check for now
-            false
-          end
+        when String
+          val == TRUE_STRING
         else
           val
         end

--- a/lib/protobuf/field/bytes_field.rb
+++ b/lib/protobuf/field/bytes_field.rb
@@ -59,11 +59,11 @@ module Protobuf
           define_method(method_name) do |val|
             begin
               case val
-              when String, Symbol then
+              when String, Symbol
                 @values[field.name] = "#{val}"
-              when NilClass then
+              when NilClass
                 @values.delete(field.name)
-              when ::Protobuf::Message then
+              when ::Protobuf::Message
                 @values[field.name] = val.dup
               else
                 fail TypeError, "Unacceptable value #{val} for field #{field.name} of type #{field.type_class}"

--- a/lib/protobuf/field/bytes_field.rb
+++ b/lib/protobuf/field/bytes_field.rb
@@ -23,7 +23,7 @@ module Protobuf
       #
 
       def acceptable?(val)
-        val.nil? || val.is_a?(String) || val.is_a?(Symbol) || val.is_a?(::Protobuf::Message)
+        val.is_a?(String) || val.nil? || val.is_a?(Symbol) || val.is_a?(::Protobuf::Message)
       end
 
       def decode(bytes)
@@ -58,11 +58,12 @@ module Protobuf
         message_class.class_eval do
           define_method(method_name) do |val|
             begin
-              val = "#{val}" if val.is_a?(Symbol)
-
-              if val.nil?
+              case val
+              when String, Symbol then
+                @values[field.name] = "#{val}"
+              when NilClass then
                 @values.delete(field.name)
-              elsif field.acceptable?(val)
+              when ::Protobuf::Message then
                 @values[field.name] = val.dup
               else
                 fail TypeError, "Unacceptable value #{val} for field #{field.name} of type #{field.type_class}"

--- a/lib/protobuf/field/message_field.rb
+++ b/lib/protobuf/field/message_field.rb
@@ -41,13 +41,13 @@ module Protobuf
         message_class.class_eval do
           define_method("#{field.name}=") do |val|
             case
-            when val.nil? then
+            when val.nil?
               @values.delete(field.name)
-            when val.is_a?(field.type_class) then
+            when val.is_a?(field.type_class)
               @values[field.name] = val
-            when val.respond_to?(:to_proto) then
+            when val.respond_to?(:to_proto)
               @values[field.name] = val.to_proto
-            when val.respond_to?(:to_hash) then
+            when val.respond_to?(:to_hash)
               @values[field.name] = field.type_class.new(val.to_hash)
             else
               fail TypeError, "Expected value of type '#{field.type_class}' for field #{field.name}, but got '#{val.class}'"

--- a/lib/protobuf/field/message_field.rb
+++ b/lib/protobuf/field/message_field.rb
@@ -9,11 +9,7 @@ module Protobuf
       #
 
       def acceptable?(val)
-        unless val.is_a?(type_class) || val.respond_to?(:to_hash)
-          fail TypeError, "Expected value of type '#{type_class}' for field #{name}, but got '#{val.class}'"
-        end
-
-        true
+        val.is_a?(type_class) || val.respond_to?(:to_hash)
       end
 
       def decode(bytes)

--- a/lib/protobuf/field/string_field.rb
+++ b/lib/protobuf/field/string_field.rb
@@ -25,8 +25,7 @@ module Protobuf
         value_to_encode.encode!(::Protobuf::Field::StringField::ENCODING, :invalid => :replace, :undef => :replace, :replace => "")
         value_to_encode.force_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
 
-        string_size = ::Protobuf::Field::VarintField.encode(value_to_encode.size)
-        string_size << value_to_encode
+        "#{::Protobuf::Field::VarintField.encode(value_to_encode.size)}#{value_to_encode}"
       end
 
     end

--- a/lib/protobuf/field/varint_field.rb
+++ b/lib/protobuf/field/varint_field.rb
@@ -8,7 +8,7 @@ module Protobuf
       # Constants
       #
 
-      CACHE_LIMIT = 1024
+      CACHE_LIMIT = 2048
       INT32_MAX  =  2**31 - 1
       INT32_MIN  = -2**31
       INT64_MAX  =  2**63 - 1
@@ -43,7 +43,7 @@ module Protobuf
       end
 
       # Load the cache of VarInts on load of file
-      (0..CACHE_LIMIT).to_a.each do |cached_value|
+      (0..CACHE_LIMIT).each do |cached_value|
         cached_varint(cached_value)
       end
 
@@ -68,15 +68,7 @@ module Protobuf
       end
 
       def encode(value)
-        return [value].pack('C') if value < 128
-
-        bytes = []
-        until value == 0
-          bytes << (0x80 | (value & 0x7f))
-          value >>= 7
-        end
-        bytes[-1] &= 0x7f
-        bytes.pack('C*')
+        ::Protobuf::Field::VarintField.encode(value)
       end
 
       def wire_type

--- a/lib/protobuf/generators/field_generator.rb
+++ b/lib/protobuf/generators/field_generator.rb
@@ -27,11 +27,11 @@ module Protobuf
         @default_value ||= begin
                              if defaulted?
                                case descriptor.type.name
-                               when :TYPE_ENUM then
+                               when :TYPE_ENUM
                                  enum_default_value
-                               when :TYPE_STRING, :TYPE_BYTES then
+                               when :TYPE_STRING, :TYPE_BYTES
                                  string_default_value
-                               when :TYPE_FLOAT, :TYPE_DOUBLE then
+                               when :TYPE_FLOAT, :TYPE_DOUBLE
                                  float_double_default_value
                                else
                                  verbatim_default_value

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -40,7 +40,7 @@ module Protobuf
 
     def initialize(fields = {})
       @values = {}
-      fields.to_hash.each_pair do |name, value|
+      fields.to_hash.each do |name, value|
         self[name] = value
       end
 

--- a/lib/protobuf/message/fields.rb
+++ b/lib/protobuf/message/fields.rb
@@ -109,11 +109,6 @@ module Protobuf
           end
         end
 
-        def field_name_store
-          @field_name_store ||= {}
-        end
-        private :field_name_store
-
         def raise_if_tag_collision(tag, field_name)
           if get_field(tag, true)
             fail TagCollisionError, %(Field number #{tag} has already been used in "#{name}" by field "#{field_name}".)

--- a/lib/protobuf/rpc/service_filters.rb
+++ b/lib/protobuf/rpc/service_filters.rb
@@ -122,7 +122,7 @@ module Protobuf
         def invoke_via_if?(_rpc_method, filter)
           if_check = filter.fetch(:if) { ->(_service) { return true } }
           do_invoke = case
-                      when if_check.nil? then
+                      when if_check.nil?
                         true
                       else
                         call_or_send(if_check)
@@ -152,7 +152,7 @@ module Protobuf
         def invoke_via_unless?(_rpc_method, filter)
           unless_check = filter.fetch(:unless) { ->(_service) { return false } }
           skip_invoke = case
-                        when unless_check.nil? then
+                        when unless_check.nil?
                           false
                         else
                           call_or_send(unless_check)
@@ -254,9 +254,9 @@ module Protobuf
         #
         def call_or_send(callable, *args, &block)
           return_value = case
-                         when callable.respond_to?(:call) then
+                         when callable.respond_to?(:call)
                            callable.call(self, *args, &block)
-                         when respond_to?(callable, true) then
+                         when respond_to?(callable, true)
                            __send__(callable, *args, &block)
                          else
                            fail "Object #{callable} is not callable"

--- a/spec/benchmark/tasks.rb
+++ b/spec/benchmark/tasks.rb
@@ -97,7 +97,7 @@ namespace :benchmark do
     args.with_defaults(:number => 1000, :profile_output => "/tmp/profiler_new_#{Time.now.to_i}")
     create_params = { :name => "The name that we set", :date_created => Time.now.to_i, :status => 2 }
     profile_code(args[:profile_output]) do
-      Integer(args[:number]).times { Test::Resource.new(create_params).serialize }
+      Integer(args[:number]).times { Test::Resource.decode(Test::Resource.new(create_params).serialize) }
     end
 
     puts args[:profile_output]

--- a/spec/benchmark/tasks.rb
+++ b/spec/benchmark/tasks.rb
@@ -107,7 +107,9 @@ namespace :benchmark do
     case RUBY_ENGINE.to_sym
     when :ruby
       profile_data = RubyProf.profile(&block)
-      RubyProf::FlatPrinter.new(profile_data).print(:path => output)
+      ::File.open(output, "w") do |output_file|
+        RubyProf::FlatPrinter.new(profile_data).print(output_file)
+      end
     when :rbx
       profiler = Rubinius::Profiler::Instrumenter.new
       profiler.profile(false, &block)


### PR DESCRIPTION
"larger" change with removing `new().encode` from encoder, creates lot of new objects and garbage during serialization without any noticeable benefit (removing took 1 second off of 14 second 100_000 record serialization)

ordering of `nil?` `is_a?` checks in string instances favored `nil?` case, but `String` case is "more common" with deserialization (as a string field would not be deserialized unless it was present during serialization) <= reordered acceptability check

added caching of varint => 2048 by default because of how wire types serialize; the shift makes 1049 a common "tag" (if > 128 fields)

removed dual varint encoders as class level will suffice (and instance level weren't cached)

removed multiple field stores in "fields" as the symbol will not negatively interact with the string and the tag; having Ruby only calculate the hash key once reduces lookup times for fields during serialization

More work to be done, but will put other changes into issues that are reported (around inconsistent serialization and deserialization concerns); looking to keep this one focused on maintaining all current behavior

@film42 @zachmargolis @mmmries 