### PR TITLE
Speed Up Creates & Updates By Memoizing on encode

### DIFF
--- a/lib/protobuf/decoder.rb
+++ b/lib/protobuf/decoder.rb
@@ -5,10 +5,10 @@ module Protobuf
   class Decoder
 
     # Read bytes from +stream+ and pass to +message+ object.
-    def self.decode_each_field(stream, &block)
+    def self.decode_each_field(stream)
       until stream.eof?
         tag, bytes = read_field(stream)
-        block.call(tag, bytes)
+        yield(tag, bytes)
       end
     end
 

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -194,7 +194,7 @@ module Protobuf
 
         message_class.class_eval do
           define_method(method_name) do |val|
-            @memoized_encoded = nil
+            @encode = nil
             if val.is_a?(Array)
               val = val.dup
               val.compact!
@@ -236,7 +236,7 @@ module Protobuf
 
         message_class.class_eval do
           define_method(method_name) do |val|
-            @memoized_encoded = nil
+            @encode = nil
             if val.nil? || (val.respond_to?(:empty?) && val.empty?)
               @values.delete(field.name)
             elsif field.acceptable?(val)

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -21,7 +21,6 @@ module Protobuf
       ##
       # Attributes
       #
-
       attr_reader :message_class, :name, :options, :rule, :tag, :type_class
 
       ##
@@ -195,6 +194,7 @@ module Protobuf
 
         message_class.class_eval do
           define_method(method_name) do |val|
+            @memoized_encoded = nil
             if val.is_a?(Array)
               val = val.dup
               val.compact!
@@ -236,6 +236,7 @@ module Protobuf
 
         message_class.class_eval do
           define_method(method_name) do |val|
+            @memoized_encoded = nil
             if val.nil? || (val.respond_to?(:empty?) && val.empty?)
               @values.delete(field.name)
             elsif field.acceptable?(val)

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -21,7 +21,6 @@ module Protobuf
       ##
       # Attributes
       #
-      attr_accessor :memoized_encoded
       attr_reader :message_class, :name, :options, :rule, :tag, :type_class
 
       ##

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -21,6 +21,7 @@ module Protobuf
       ##
       # Attributes
       #
+      attr_accessor :memoized_encoded
       attr_reader :message_class, :name, :options, :rule, :tag, :type_class
 
       ##

--- a/lib/protobuf/field/bytes_field.rb
+++ b/lib/protobuf/field/bytes_field.rb
@@ -57,7 +57,7 @@ module Protobuf
 
         message_class.class_eval do
           define_method(method_name) do |val|
-            @memoized_encoded = nil
+            @encode = nil
             begin
               case val
               when String, Symbol

--- a/lib/protobuf/field/bytes_field.rb
+++ b/lib/protobuf/field/bytes_field.rb
@@ -57,6 +57,7 @@ module Protobuf
 
         message_class.class_eval do
           define_method(method_name) do |val|
+            @memoized_encoded = nil
             begin
               case val
               when String, Symbol

--- a/lib/protobuf/field/enum_field.rb
+++ b/lib/protobuf/field/enum_field.rb
@@ -42,6 +42,7 @@ module Protobuf
         field = self
         message_class.class_eval do
           define_method("#{field.name}=") do |value|
+            @memoized_encoded = nil
             orig_value = value
             if value.nil?
               @values.delete(field.name)

--- a/lib/protobuf/field/enum_field.rb
+++ b/lib/protobuf/field/enum_field.rb
@@ -42,7 +42,7 @@ module Protobuf
         field = self
         message_class.class_eval do
           define_method("#{field.name}=") do |value|
-            @memoized_encoded = nil
+            @encode = nil
             orig_value = value
             if value.nil?
               @values.delete(field.name)

--- a/lib/protobuf/field/message_field.rb
+++ b/lib/protobuf/field/message_field.rb
@@ -40,6 +40,7 @@ module Protobuf
         field = self
         message_class.class_eval do
           define_method("#{field.name}=") do |val|
+            @memoized_encoded = nil
             case
             when val.nil?
               @values.delete(field.name)

--- a/lib/protobuf/field/message_field.rb
+++ b/lib/protobuf/field/message_field.rb
@@ -40,7 +40,7 @@ module Protobuf
         field = self
         message_class.class_eval do
           define_method("#{field.name}=") do |val|
-            @memoized_encoded = nil
+            @encode = nil
             case
             when val.nil?
               @values.delete(field.name)

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -27,11 +27,6 @@ module Protobuf
     include ::Protobuf::Message::Serialization
 
     ##
-    # Attributes
-    #
-    attr_accessor :memoized_encoded
-
-    ##
     # Class Methods
     #
 

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -27,6 +27,11 @@ module Protobuf
     include ::Protobuf::Message::Serialization
 
     ##
+    # Attributes
+    #
+    attr_accessor :memoized_encoded
+
+    ##
     # Class Methods
     #
 

--- a/lib/protobuf/message/serialization.rb
+++ b/lib/protobuf/message/serialization.rb
@@ -48,7 +48,7 @@ module Protobuf
       # Encode this message
       #
       def encode
-        @memoized_encoded ||= begin
+        @encode ||= begin
           stream = ::StringIO.new
           stream.set_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
           encode_to(stream)

--- a/lib/protobuf/message/serialization.rb
+++ b/lib/protobuf/message/serialization.rb
@@ -48,10 +48,12 @@ module Protobuf
       # Encode this message
       #
       def encode
-        stream = ::StringIO.new
-        stream.set_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
-        encode_to(stream)
-        stream.string
+        @memoized_encoded ||= begin
+          stream = ::StringIO.new
+          stream.set_encoding(::Protobuf::Field::BytesField::BYTES_ENCODING)
+          encode_to(stream)
+          stream.string
+        end
       end
 
       # Encode this message to the given stream.

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -272,9 +272,9 @@ RSpec.describe Protobuf::Message do
       it "should memoize enum message" do
         test_enum = Test::EnumTestMessage.new
         test_enum.encode
-        expect(test_enum.instance_variable_get(:@memoized_encoded)).to eq("")
+        expect(test_enum.instance_variable_get(:@encode)).to eq("")
         test_enum.non_default_enum = 2
-        expect(test_enum.instance_variable_get(:@memoized_encoded)).to be_nil
+        expect(test_enum.instance_variable_get(:@encode)).to be_nil
       end
 
       context "boolean fields" do
@@ -283,9 +283,9 @@ RSpec.describe Protobuf::Message do
 
         it "should memoize after bool values change " do
           test_resource.encode
-          expect(test_resource.instance_variable_get(:@memoized_encoded)).to eq(test_resource.encode)
+          expect(test_resource.instance_variable_get(:@encode)).to eq(test_resource.encode)
           test_resource.ext_is_searchable = false
-          expect(test_resource.instance_variable_get(:@memoized_encoded)).to be_nil
+          expect(test_resource.instance_variable_get(:@encode)).to be_nil
         end
       end
 
@@ -295,9 +295,9 @@ RSpec.describe Protobuf::Message do
 
         it "should memoize after bool values change " do
           test_resource.encode
-          expect(test_resource.instance_variable_get(:@memoized_encoded)).to eq(test_resource.encode)
+          expect(test_resource.instance_variable_get(:@encode)).to eq(test_resource.encode)
           test_resource.name = "MVP"
-          expect(test_resource.instance_variable_get(:@memoized_encoded)).to be_nil
+          expect(test_resource.instance_variable_get(:@encode)).to be_nil
         end
       end
 
@@ -307,9 +307,9 @@ RSpec.describe Protobuf::Message do
 
         it "should memoize after string values change " do
           test_resource.encode
-          expect(test_resource.instance_variable_get(:@memoized_encoded)).to eq(test_resource.encode)
+          expect(test_resource.instance_variable_get(:@encode)).to eq(test_resource.encode)
           test_resource.name = "MVP"
-          expect(test_resource.instance_variable_get(:@memoized_encoded)).to be_nil
+          expect(test_resource.instance_variable_get(:@encode)).to be_nil
         end
       end
 
@@ -319,9 +319,9 @@ RSpec.describe Protobuf::Message do
 
         it "should memoize after Int64 values change " do
           test_resource.encode
-          expect(test_resource.instance_variable_get(:@memoized_encoded)).to eq(test_resource.encode)
+          expect(test_resource.instance_variable_get(:@encode)).to eq(test_resource.encode)
           test_resource.date_created =  5554712127
-          expect(test_resource.instance_variable_get(:@memoized_encoded)).to be_nil
+          expect(test_resource.instance_variable_get(:@encode)).to be_nil
         end
       end
     end

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -268,6 +268,64 @@ RSpec.describe Protobuf::Message do
       end
     end
 
+    describe 'memoization' do
+      it "should memoize enum message" do
+        test_enum = Test::EnumTestMessage.new
+        test_enum.encode
+        expect(test_enum.instance_variable_get(:@memoized_encoded)).to eq("")
+        test_enum.non_default_enum = 2
+        expect(test_enum.instance_variable_get(:@memoized_encoded)).to be_nil
+      end
+
+      context "boolean fields" do
+        let(:values) { { :ext_is_searchable => true, :name => "STEPH CURRY" } }
+        let(:test_resource) { ::Test::Resource.new(values) }
+
+        it "should memoize after bool values change " do
+          test_resource.encode
+          expect(test_resource.instance_variable_get(:@memoized_encoded)).to eq(test_resource.encode)
+          test_resource.ext_is_searchable = false
+          expect(test_resource.instance_variable_get(:@memoized_encoded)).to be_nil
+        end
+      end
+
+      context "string" do
+        let(:values) { { :ext_is_searchable => true, :name => "STEPH CURRY" } }
+        let(:test_resource) { ::Test::Resource.new(values) }
+
+        it "should memoize after bool values change " do
+          test_resource.encode
+          expect(test_resource.instance_variable_get(:@memoized_encoded)).to eq(test_resource.encode)
+          test_resource.name = "MVP"
+          expect(test_resource.instance_variable_get(:@memoized_encoded)).to be_nil
+        end
+      end
+
+      context "string" do
+        let(:values) { { :ext_is_searchable => true, :name => "STEPH CURRY" } }
+        let(:test_resource) { ::Test::Resource.new(values) }
+
+        it "should memoize after string values change " do
+          test_resource.encode
+          expect(test_resource.instance_variable_get(:@memoized_encoded)).to eq(test_resource.encode)
+          test_resource.name = "MVP"
+          expect(test_resource.instance_variable_get(:@memoized_encoded)).to be_nil
+        end
+      end
+
+      context "Int64" do
+        let(:values) { { :name => "STEPH CURRY", :date_created => 1454712125 } }
+        let(:test_resource) { ::Test::Resource.new(values) }
+
+        it "should memoize after Int64 values change " do
+          test_resource.encode
+          expect(test_resource.instance_variable_get(:@memoized_encoded)).to eq(test_resource.encode)
+          test_resource.date_created =  5554712127
+          expect(test_resource.instance_variable_get(:@memoized_encoded)).to be_nil
+        end
+      end
+    end
+
     context "when there's no value for a required field" do
       let(:message) { ::Test::ResourceWithRequiredField.new }
 


### PR DESCRIPTION
Serialization is one of the slowest things that you do in Protobuf. If we already have an encoded message, then we don't need to encode it again so why not memoize it. 

@abrandoned @liveh2o @mmmries @brianstien 