### PR TITLE
Abrandoned/decoding setters without copy

### DIFF
--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -176,6 +176,7 @@ module Protobuf
         else
           define_getter
           define_setter
+          define_decode_setter
         end
       end
 
@@ -232,6 +233,10 @@ module Protobuf
         end
 
         ::Protobuf.field_deprecator.deprecate_method(message_class, method_name) if field.deprecated?
+      end
+
+      def define_decode_setter
+        # empty for now
       end
 
       def define_setter

--- a/lib/protobuf/field/bool_field.rb
+++ b/lib/protobuf/field/bool_field.rb
@@ -35,6 +35,20 @@ module Protobuf
         value == 1
       end
 
+      def define_decode_setter
+        field = self
+        name_method_name = "_protobuf_decode_setter_#{field.name}"
+        tag_method_name = "_protobuf_decode_setter_#{field.tag}"
+
+        message_class.class_eval do
+          define_method(name_method_name) do |val|
+            @values[field.name] = field.decode(val)
+          end
+
+          alias_method tag_method_name, name_method_name
+        end
+      end
+
       def encode(value)
         [value ? 1 : 0].pack('C')
       end

--- a/lib/protobuf/field/bytes_field.rb
+++ b/lib/protobuf/field/bytes_field.rb
@@ -56,6 +56,21 @@ module Protobuf
       # Private Instance Methods
       #
 
+      def define_decode_setter
+        field = self
+        name_method_name = "_protobuf_decode_setter_#{field.name}"
+        tag_method_name = "_protobuf_decode_setter_#{field.tag}"
+
+        message_class.class_eval do
+          define_method(name_method_name) do |val|
+            @encode = nil
+            @values[field.name] = field.decode(val)
+          end
+
+          alias_method tag_method_name, name_method_name
+        end
+      end
+
       def define_setter
         field = self
         method_name = field.setter

--- a/lib/protobuf/field/enum_field.rb
+++ b/lib/protobuf/field/enum_field.rb
@@ -38,6 +38,20 @@ module Protobuf
       # Private Instance Methods
       #
 
+      def define_decode_setter
+        field = self
+        name_method_name = "_protobuf_decode_setter_#{field.name}"
+        tag_method_name = "_protobuf_decode_setter_#{field.tag}"
+
+        message_class.class_eval do
+          define_method(name_method_name) do |val|
+            @values[field.name] = field.decode(val)
+          end
+
+          alias_method tag_method_name, name_method_name
+        end
+      end
+
       def define_setter
         field = self
         message_class.class_eval do

--- a/lib/protobuf/field/integer_field.rb
+++ b/lib/protobuf/field/integer_field.rb
@@ -13,6 +13,20 @@ module Protobuf
         value
       end
 
+      def define_decode_setter
+        field = self
+        name_method_name = "_protobuf_decode_setter_#{field.name}"
+        tag_method_name = "_protobuf_decode_setter_#{field.tag}"
+
+        message_class.class_eval do
+          define_method(name_method_name) do |val|
+            @values[field.name] = field.decode(val)
+          end
+
+          alias_method tag_method_name, name_method_name
+        end
+      end
+
       def encode(value)
         # original Google's library uses 64bits integer for negative value
         ::Protobuf::Field::VarintField.encode(value & 0xffff_ffff_ffff_ffff)

--- a/lib/protobuf/field/message_field.rb
+++ b/lib/protobuf/field/message_field.rb
@@ -17,9 +17,7 @@ module Protobuf
       end
 
       def encode(value)
-        bytes = value.encode
-        result = ::Protobuf::Field::VarintField.encode(bytes.size)
-        result << bytes
+        "#{::Protobuf::Field::VarintField.encode(value.encode.size)}#{value.encode}"
       end
 
       def message?

--- a/lib/protobuf/field/signed_integer_field.rb
+++ b/lib/protobuf/field/signed_integer_field.rb
@@ -16,6 +16,20 @@ module Protobuf
         end
       end
 
+      def define_decode_setter
+        field = self
+        name_method_name = "_protobuf_decode_setter_#{field.name}"
+        tag_method_name = "_protobuf_decode_setter_#{field.tag}"
+
+        message_class.class_eval do
+          define_method(name_method_name) do |val|
+            @values[field.name] = field.decode(val)
+          end
+
+          alias_method tag_method_name, name_method_name
+        end
+      end
+
       def encode(value)
         if value >= 0
           VarintField.encode(value << 1)

--- a/lib/protobuf/field/string_field.rb
+++ b/lib/protobuf/field/string_field.rb
@@ -20,6 +20,21 @@ module Protobuf
         bytes_to_decode
       end
 
+      def define_decode_setter
+        field = self
+        name_method_name = "_protobuf_decode_setter_#{field.name}"
+        tag_method_name = "_protobuf_decode_setter_#{field.tag}"
+
+        message_class.class_eval do
+          define_method(name_method_name) do |val|
+            val.force_encoding(::Protobuf::Field::StringField::ENCODING)
+            @values[field.name] = val
+          end
+
+          alias_method tag_method_name, name_method_name
+        end
+      end
+
       def encode(value)
         value_to_encode = value.dup
         value_to_encode.encode!(::Protobuf::Field::StringField::ENCODING, :invalid => :replace, :undef => :replace, :replace => "")

--- a/lib/protobuf/field/varint_field.rb
+++ b/lib/protobuf/field/varint_field.rb
@@ -63,6 +63,20 @@ module Protobuf
         Integer(val, 10)
       end
 
+      def define_decode_setter
+        field = self
+        name_method_name = "_protobuf_decode_setter_#{field.name}"
+        tag_method_name = "_protobuf_decode_setter_#{field.tag}"
+
+        message_class.class_eval do
+          define_method(name_method_name) do |val|
+            @values[field.name] = val
+          end
+
+          alias_method tag_method_name, name_method_name
+        end
+      end
+
       def decode(value)
         value
       end

--- a/lib/protobuf/field/varint_field.rb
+++ b/lib/protobuf/field/varint_field.rb
@@ -52,6 +52,7 @@ module Protobuf
       #
 
       def acceptable?(val)
+        return true if val.is_a?(Integer) && val >= 0 && val < INT32_MAX
         int_val = coerce!(val)
         int_val >= self.class.min && int_val <= self.class.max
       rescue

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -77,8 +77,7 @@ module Protobuf
       return to_enum(:each_field) unless block_given?
 
       self.class.all_fields.each do |field|
-        value = __send__(field.getter)
-        yield(field, value)
+        yield(field, __send__(field.getter))
       end
     end
 

--- a/lib/protobuf/message/serialization.rb
+++ b/lib/protobuf/message/serialization.rb
@@ -78,6 +78,9 @@ module Protobuf
       private
 
       def set_field_bytes(tag, bytes)
+        tag_setter_name = "_protobuf_decode_setter_#{tag}"
+        return __send__(tag_setter_name, bytes) if respond_to?(tag_setter_name)
+
         field = self.class.get_field(tag, true)
         field.set(self, bytes) if field
       end


### PR DESCRIPTION
start moving towards per field decoding setters instead of using the standard setter during the decode routine; the standard setter does copies to keep from mutating an incoming value when a value is set, during decode we also make a copy as a result of pulling it off the stream, largely reduces a single copy and in cases where we can it prevents the acceptable? checks as a value that has been serialized and is tagged should be acceptable

also started added setters directly on the message object by tag instead of doing a field lookup and then running through the name of the field; reduces the amount of searching for field definitions and will eventually lead to us having a deserialization routine that only utilizes tags (instead of field lookup)

on MRI and JRuby these changes accounted for ~20% decrease in time for serialization/deserialization of the command
`bx rake benchmark:profile_protobuf_serialize[100000,prof_out.txt]`

@film42 