### PR TITLE
Fix #define_getter method

### DIFF
--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -227,7 +227,7 @@ module Protobuf
 
         message_class.class_eval do
           define_method(method_name) do
-            @values[field.name] || field.default_value
+            @values.fetch(field.name, field.default_value)
           end
         end
 

--- a/spec/lib/protobuf/field/bool_field_spec.rb
+++ b/spec/lib/protobuf/field/bool_field_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Protobuf::Field::Int32Field do
 
   class SomeBoolMessage < ::Protobuf::Message
     optional :bool, :some_bool, 1
+    required :bool, :required_bool, 2
   end
 
   let(:instance) { SomeBoolMessage.new }
@@ -48,4 +49,13 @@ RSpec.describe Protobuf::Field::Int32Field do
     end
   end
 
+  describe '#define_getter' do
+    context 'when required bool field is set to false' do
+      subject { instance.required_bool = false; instance.required_bool }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
If a required bool field is set to `false`, `#define_getter` returns its default value(=nil) wrongly because of the following code.

https://github.com/ruby-protobuf/protobuf/blob/master/lib/protobuf/field/base_field.rb#L230
```ruby
def define_getter
---
  @values[field.name] || field.default_value
```

This behavor was introduced by [this commit](https://github.com/ruby-protobuf/protobuf/commit/05aa7756e489e792c7bb0785ef2979931a4879a6)

This commit fixes the above issue