### PR TITLE
teach protoc-gen-ruby PB_{DUMP,LOAD}_REQUEST_BYTES

### DIFF
--- a/bin/protoc-gen-ruby
+++ b/bin/protoc-gen-ruby
@@ -10,7 +10,23 @@ require 'protobuf'
 require 'protobuf/descriptors'
 require 'protobuf/code_generator'
 
-request_bytes = STDIN.read
+if ENV['PB_LOAD_REQUEST_BYTES']
+  request_bytes = File.read(ENV['PB_LOAD_REQUEST_BYTES'])
+else
+  request_bytes = STDIN.read
+end
+if ENV['PB_DUMP_REQUEST_BYTES']
+  dump_file = ENV['PB_DUMP_REQUEST_BYTES']
+  unless File.directory?(File.dirname(dump_file))
+    warn "PB_DUMP_REQUEST_BYTES=#{dump_file.inspect} is not a valid path for the request bytes"
+    warn "Usage: PB_DUMP_REQUEST_BYTES=/path/to/desired/dump/file.bin protoc blah.proto"
+    exit 1
+  end
+  File.open(dump_file, 'w') do |f|
+    f.print(request_bytes)
+  end
+  exit 1
+end
 code_generator = ::Protobuf::CodeGenerator.new(request_bytes)
 response_bytes = code_generator.response_bytes
 STDOUT.print(response_bytes)


### PR DESCRIPTION
`PB_DUMP_REQUEST_BYTES=foo.bin protoc foo.proto --plugin=protoc-gen-gem=bin/protoc-gen-ruby --gem_out=.`
will dump the raw proto request bytes generated by protoc for foo.proto to foo.bin
FUTURE USE CASE: functional tests to come that rely on checked-in bin files

`PB_LOAD_REQUEST_BYTES=foo.bin bin/protoc-gen-ruby`
will read the raw request bytes from foo.bin and print the generated
code (actually it is the code gen response proto, but it is still
readable) to STDOUT
CURRENT USE CASE: makes it so you can use `pry` when testing code generation. If you gave the code generator input from stdin, then `pry` would get the command to close at the end of the stdin input.
