### PR TITLE
Small optimizations

### DIFF
--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -177,16 +177,19 @@ module Protobuf
       #
 
       def define_accessor(simple_field_name, fully_qualified_field_name)
-        message_class.class_eval do
-          define_method("#{simple_field_name}!") do
-            @values[fully_qualified_field_name]
+        message_class.class_eval <<-ruby, __FILE__, __LINE__
+          def #{simple_field_name}!
+            @values[:#{fully_qualified_field_name}]
           end
-        end
 
-        message_class.class_eval do
-          define_method(simple_field_name) { self[fully_qualified_field_name] }
-          define_method("#{simple_field_name}=") { |v| self[fully_qualified_field_name] = v }
-        end
+          def #{simple_field_name}
+            self[:#{fully_qualified_field_name}]
+          end
+
+          def #{simple_field_name}=(value)
+            self[:#{fully_qualified_field_name}] = value
+          end
+        ruby
 
         return unless deprecated?
 

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -179,15 +179,15 @@ module Protobuf
       def define_accessor(simple_field_name, fully_qualified_field_name)
         message_class.class_eval <<-ruby, __FILE__, __LINE__
           def #{simple_field_name}!
-            @values[:#{fully_qualified_field_name}]
+            @values[:"#{fully_qualified_field_name}"]
           end
 
           def #{simple_field_name}
-            self[:#{fully_qualified_field_name}]
+            self[:"#{fully_qualified_field_name}"]
           end
 
           def #{simple_field_name}=(value)
-            self[:#{fully_qualified_field_name}] = value
+            self[:"#{fully_qualified_field_name}"] = value
           end
         ruby
 

--- a/lib/protobuf/field/integer_field.rb
+++ b/lib/protobuf/field/integer_field.rb
@@ -9,7 +9,7 @@ module Protobuf
       #
 
       def decode(value)
-        value -= 0x1_0000_0000_0000_0000 if (value & 0x8000_0000_0000_0000).nonzero?
+        value -= 0x1_0000_0000_0000_0000 if (value & 0x8000_0000_0000_0000) != 0
         value
       end
 

--- a/lib/protobuf/field/sfixed32_field.rb
+++ b/lib/protobuf/field/sfixed32_field.rb
@@ -10,7 +10,7 @@ module Protobuf
 
       def decode(bytes)
         value  = bytes.unpack('V').first
-        value -= 0x1_0000_0000 if (value & 0x8000_0000).nonzero?
+        value -= 0x1_0000_0000 if (value & 0x8000_0000) != 0
         value
       end
 

--- a/lib/protobuf/field/sfixed64_field.rb
+++ b/lib/protobuf/field/sfixed64_field.rb
@@ -11,7 +11,7 @@ module Protobuf
       def decode(bytes)
         values = bytes.unpack('VV') # 'Q' is machine-dependent, don't use
         value  = values[0] + (values[1] << 32)
-        value -= 0x1_0000_0000_0000_0000 if (value & 0x8000_0000_0000_0000).nonzero?
+        value -= 0x1_0000_0000_0000_0000 if (value & 0x8000_0000_0000_0000) != 0
         value
       end
 

--- a/lib/protobuf/field/signed_integer_field.rb
+++ b/lib/protobuf/field/signed_integer_field.rb
@@ -9,7 +9,7 @@ module Protobuf
       #
 
       def decode(value)
-        if (value & 1).zero?
+        if (value & 1) == 0
           value >> 1   # positive value
         else
           ~value >> 1  # negative value

--- a/lib/protobuf/varint_pure.rb
+++ b/lib/protobuf/varint_pure.rb
@@ -1,12 +1,12 @@
 module Protobuf
   module VarintPure
     def decode(stream)
-      value = index = 0
+      value = shift = 0
       begin
         byte = stream.readbyte
-        value |= (byte & 0x7f) << (7 * index)
-        index += 1
-      end while (byte & 0x80).nonzero?
+        value |= (byte & 127) << shift
+        shift += 7
+      end while byte > 127
       value
     end
   end

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -24,6 +24,7 @@ require "protobuf/version"
   s.add_dependency 'thor'
   s.add_dependency 'thread_safe'
 
+  s.add_development_dependency 'benchmark-ips'
   s.add_development_dependency 'ffi-rzmq'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3.0'
@@ -31,7 +32,6 @@ require "protobuf/version"
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'benchmark-ips'
 
   # debuggers only work in MRI
   if RUBY_ENGINE.to_sym == :ruby

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -31,6 +31,7 @@ require "protobuf/version"
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'yard'
+  s.add_development_dependency 'benchmark-ips'
 
   # debuggers only work in MRI
   if RUBY_ENGINE.to_sym == :ruby


### PR DESCRIPTION
This just adds a few speedups.
1. `class_eval` string - This turned out to be about 40% faster for setters and 48% faster for getters (for both MRI and Jruby). Here's my benchmark: https://gist.github.com/film42/8efd4810d3c5a5e12291.
2. Varint - This takes the optimized varint out of https://github.com/ruby-protobuf/protobuf/pull/297.
3. `nonzero?` vs `!= 0` - Declarative methods are nice, but simple operators are still very readable and more performant, especially in these hot code paths.

Note: I also added `benchmark-ips` as a dev dependency because I end up using it a lot when working with protobuf.

cc @abrandoned @zachmargolis @embark 
