### PR TITLE
Empty values should not clear a protobuf field

### DIFF
--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -178,7 +178,7 @@ module Protobuf
             @values[field.name].replace(value)
           end
         else
-          if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+          if value.nil?
             @values.delete(field.name)
           elsif field.acceptable?(value)
             @values[field.name] = field.coerce!(value)


### PR DESCRIPTION
Before commit #302, empty? values never cleared a proto field unless the field was a Fixnum or boolean type (which didn't make any sense, and was probably unused, anyway).