### PR TITLE
Preserve raw RPC name (since #underscore can be lossy)

### DIFF
--- a/lib/protobuf/generators/service_generator.rb
+++ b/lib/protobuf/generators/service_generator.rb
@@ -15,10 +15,10 @@ module Protobuf
       end
 
       def build_method(method_descriptor)
-        name = method_descriptor.name
         request_klass = modulize(method_descriptor.input_type)
         response_klass = modulize(method_descriptor.output_type)
-        "rpc :#{name.underscore}, #{request_klass}, #{response_klass}"
+        name = ENV.key?('PB_USE_RAW_RPC_NAMES') ? method_descriptor.name : method_descriptor.name.underscore
+        "rpc :#{name}, #{request_klass}, #{response_klass}"
       end
 
     end

--- a/spec/lib/protobuf/generators/service_generator_spec.rb
+++ b/spec/lib/protobuf/generators/service_generator_spec.rb
@@ -41,6 +41,15 @@ end
     it 'returns a string identifying the given method descriptor' do
       expect(subject.build_method(service.method.first)).to eq("rpc :search, FooRequest, FooResponse")
     end
+
+    context 'with PB_USE_RAW_RPC_NAMES in the environemnt' do
+      before { allow(ENV).to receive(:key?).with('PB_USE_RAW_RPC_NAMES').and_return(true) }
+
+      it 'uses the raw RPC name and does not underscore it' do
+        expect(subject.build_method(service.method.first)).to eq("rpc :Search, FooRequest, FooResponse")
+        expect(subject.build_method(service.method.last)).to eq("rpc :FooBar, ::Foo::Request, ::Bar::Response")
+      end
+    end
   end
 
 end


### PR DESCRIPTION
cc @nerdrew @embark 

We found some RPC names that were not the same in a roundtrip of `name.underscore.camelize` so this preserves the raw data
