### PR TITLE
Properly encode and decode negative enum values

### DIFF
--- a/lib/protobuf/field/enum_field.rb
+++ b/lib/protobuf/field/enum_field.rb
@@ -1,8 +1,8 @@
-require 'protobuf/field/varint_field'
+require 'protobuf/field/integer_field'
 
 module Protobuf
   module Field
-    class EnumField < VarintField
+    class EnumField < IntegerField
 
       ##
       # Class Methods
@@ -25,7 +25,8 @@ module Protobuf
       end
 
       def decode(value)
-        value if acceptable?(value)
+        decoded = super(value)
+        decoded if acceptable?(decoded)
       end
 
       def enum?

--- a/spec/lib/protobuf/field/enum_field_spec.rb
+++ b/spec/lib/protobuf/field/enum_field_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::EnumField do
+  let(:message) do
+    Class.new(::Protobuf::Message) do
+      enum_class = Class.new(::Protobuf::Enum) do
+        define :POSITIVE, 22
+        define :NEGATIVE, -33
+      end
+
+      optional enum_class, :enum, 1
+    end
+  end
+
+  describe '.{encode, decode}' do
+    it 'handles positive enum constants' do
+      instance = message.new(:enum => :POSITIVE)
+      expect(message.decode(instance.encode).enum).to eq(22)
+    end
+
+    it 'handles negative enum constants' do
+      instance = message.new(:enum => :NEGATIVE)
+      expect(message.decode(instance.encode).enum).to eq(-33)
+    end
+  end
+end


### PR DESCRIPTION
From proto2 guide: Enumerator constants must be in the range of a 32-bit integer. Since enum values use varint encoding on the wire, negative values are inefficient and thus not recommended.

Before this change, enum values were incorrectly treated as uint values, and negative values would cause this error in the Varint gem:
`no implicit conversion from nil to integer`