### PR TITLE
Add option to name a package from file name if necessary

### DIFF
--- a/lib/protobuf/generators/file_generator.rb
+++ b/lib/protobuf/generators/file_generator.rb
@@ -123,6 +123,9 @@ module Protobuf
 
       def print_package(&block)
         namespaces = descriptor.package.split('.')
+        if namespaces.empty? && ENV.key?('PB_ALLOW_DEFAULT_PACKAGE_NAME')
+          namespaces = [File.basename(descriptor.name).sub('.proto', '')]
+        end
         namespaces.reverse.reduce(block) do |previous, namespace|
           -> { print_module(namespace, &previous) }
         end.call

--- a/spec/lib/protobuf/generators/file_generator_spec.rb
+++ b/spec/lib/protobuf/generators/file_generator_spec.rb
@@ -29,4 +29,37 @@ RSpec.describe ::Protobuf::Generators::FileGenerator do
 
   end
 
+  describe '#compile' do
+    it 'generates the file contents' do
+      subject.compile
+      expect(subject.to_s).to eq <<EOF
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf/message'
+
+EOF
+    end
+
+    it 'generates the file contents using default package name' do
+      allow(ENV).to receive(:key?).with('PB_ALLOW_DEFAULT_PACKAGE_NAME')
+        .and_return(true)
+      subject.compile
+      expect(subject.to_s).to eq <<EOF
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf/message'
+
+module Foo
+end
+
+EOF
+    end
+  end
+
 end


### PR DESCRIPTION
Next in the series of PRs that gets us closer to custom options!
We will always need a package name if we want to support custom file options and there isn't a base module to define those custom file options on.

This is how other languages handle an unspecified package name, [I'm pretty sure].

CC @nerdrew @film42 