### PR TITLE
Make all things Optionable and fix requires

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,9 @@ Style/IndentHash:
 Style/Semicolon:
   AllowAsExpressionSeparator: true
 
+Style/SingleLineBlockParams:
+  Enabled: false
+
 Style/TrailingBlankLines:
   Exclude:
     - '**/*.pb.rb'

--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -9,7 +9,24 @@ require 'active_support/inflector'
 require 'active_support/json'
 require 'active_support/notifications'
 
+# All top-level run time code requires, ordered by necessity
+require 'protobuf/wire_type'
+
+require 'protobuf/varint_pure'
+require 'protobuf/varint'
+
+require 'protobuf/exceptions'
 require 'protobuf/deprecation'
+require 'protobuf/logging'
+
+require 'protobuf/encoder'
+require 'protobuf/decoder'
+
+require 'protobuf/optionable'
+require 'protobuf/field'
+require 'protobuf/enum'
+require 'protobuf/message'
+require 'protobuf/descriptors'
 
 module Protobuf
 

--- a/lib/protobuf/decoder.rb
+++ b/lib/protobuf/decoder.rb
@@ -1,6 +1,3 @@
-require 'protobuf/wire_type'
-require 'protobuf/exceptions'
-
 module Protobuf
   class Decoder
 

--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -1,6 +1,4 @@
 require 'delegate'
-require 'protobuf/deprecation'
-require 'protobuf/optionable'
 
 ##
 # Adding extension to Numeric until

--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -10,7 +10,7 @@ require 'delegate'
 module Protobuf
   class Enum < SimpleDelegator
     # Public: Allows setting Options on the Enum class.
-    include ::Protobuf::Optionable
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::EnumOptions }
 
     def self.aliases_allowed?
       get_option(:allow_alias)

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -3,6 +3,7 @@ module Protobuf
   module Field
     class BaseField
       include ::Protobuf::Logging
+      ::Protobuf::Optionable.inject(self, false) { ::Google::Protobuf::FieldOptions }
 
       ##
       # Constants

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -1,8 +1,4 @@
-require 'protobuf/deprecation'
 require 'protobuf/field/field_array'
-require 'protobuf/logging'
-require 'protobuf/wire_type'
-
 module Protobuf
   module Field
     class BaseField

--- a/lib/protobuf/generators/file_generator.rb
+++ b/lib/protobuf/generators/file_generator.rb
@@ -104,7 +104,7 @@ module Protobuf
       end
 
       def print_generic_requires
-        print_require("protobuf/message")
+        print_require("protobuf")
         print_require("protobuf/rpc/service") if descriptor.service.count > 0
         puts
       end

--- a/lib/protobuf/generators/file_generator.rb
+++ b/lib/protobuf/generators/file_generator.rb
@@ -29,6 +29,7 @@ module Protobuf
           print_import_requires
 
           print_package do
+            inject_optionable
             group = GroupGenerator.new(current_indent)
             group.add_enums(descriptor.enum_type, :namespace => [descriptor.package])
             group.add_message_declarations(descriptor.message_type)
@@ -141,6 +142,10 @@ module Protobuf
         token[0] == '.'
       end
 
+      def inject_optionable
+        return if descriptor.package.empty? && !ENV.key?('PB_ALLOW_DEFAULT_PACKAGE_NAME')
+        puts "::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }"
+      end
     end
   end
 end

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -21,6 +21,7 @@ module Protobuf
 
     extend ::Protobuf::Message::Fields
     include ::Protobuf::Message::Serialization
+    ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::MessageOptions }
 
     ##
     # Class Methods

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -1,7 +1,3 @@
-require 'protobuf/field'
-require 'protobuf/deprecation'
-require 'protobuf/enum'
-require 'protobuf/exceptions'
 require 'protobuf/message/fields'
 require 'protobuf/message/serialization'
 

--- a/lib/protobuf/optionable.rb
+++ b/lib/protobuf/optionable.rb
@@ -1,17 +1,36 @@
-require 'active_support/concern'
-
 module Protobuf
   module Optionable
-    extend ::ActiveSupport::Concern
-
     module ClassMethods
       def get_option(name)
-        @_optionable_options.try(:[], name)
+        name = name.to_s
+        option = optionable_descriptor_class.get_field(name, true)
+        fail ArgumentError, "invalid option=#{name}" unless option
+        unless option.fully_qualified_name.to_s == name
+          # Eventually we'll deprecate the use of simple names of fields completely, but for now make sure people
+          # are accessing options correctly. We allow simple names in other places for backwards compatibility.
+          fail ArgumentError, "must access option using its fully qualified name: #{option.fully_qualified_name.inspect}"
+        end
+        if @_optionable_options.try(:key?, name)
+          value = @_optionable_options[name]
+        else
+          value = option.default_value
+        end
+        if option.type_class < ::Protobuf::Message
+          option.type_class.new(value)
+        else
+          value
+        end
       end
+
+      def get_option!(name)
+        get_option(name) if @_optionable_options.try(:key?, name.to_s)
+      end
+
+      private
 
       def set_option(name, value = true)
         @_optionable_options ||= {}
-        @_optionable_options[name] = value
+        @_optionable_options[name.to_s] = value
       end
     end
 
@@ -19,5 +38,33 @@ module Protobuf
       self.class.get_option(name)
     end
 
+    def get_option!(name)
+      self.class.get_option!(name)
+    end
+
+    def self.inject(base_class, extend_class = true, &block)
+      unless block_given?
+        fail ArgumentError, 'missing option class block (e.g: ::Google::Protobuf::MessageOptions)'
+      end
+      if extend_class
+        # Check if optionable_descriptor_class is already defined and short circuit if so.
+        # File options are injected per module, and since a module can be defined more than once,
+        # we will get a warning if we try to define optionable_descriptor_class twice.
+        if base_class.respond_to?(:optionable_descriptor_class)
+          if base_class.optionable_descriptor_class != block.call
+            fail 'A class is being defined with two different descriptor classes, something is very wrong'
+          else
+            return # Don't define optionable_descriptor_class twice
+          end
+        end
+
+        base_class.extend(ClassMethods)
+        base_class.__send__(:include, self)
+        base_class.define_singleton_method(:optionable_descriptor_class, block)
+      else
+        base_class.__send__(:include, ClassMethods)
+        base_class.module_eval { define_method(:optionable_descriptor_class, block) }
+      end
+    end
   end
 end

--- a/lib/protobuf/rpc/service.rb
+++ b/lib/protobuf/rpc/service.rb
@@ -1,6 +1,5 @@
-require 'active_support/core_ext/class'
-
 require 'protobuf/logging'
+require 'protobuf/message'
 require 'protobuf/rpc/client'
 require 'protobuf/rpc/error'
 require 'protobuf/rpc/service_filters'
@@ -14,6 +13,7 @@ module Protobuf
     class Service
       include ::Protobuf::Logging
       include ::Protobuf::Rpc::ServiceFilters
+      ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::ServiceOptions }
 
       DEFAULT_HOST = '127.0.0.1'.freeze
       DEFAULT_PORT = 9399

--- a/lib/protobuf/varint.rb
+++ b/lib/protobuf/varint.rb
@@ -1,5 +1,3 @@
-require 'protobuf/varint_pure'
-
 module Protobuf
   class Varint
     if defined?(::Varint)

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Protobuf::Enum do
     end
 
     describe '.aliases_allowed?' do
-      it 'is nil when the option is not set' do
-        expect(Test::EnumTestType.aliases_allowed?).to be nil
+      it 'is false when the option is not set' do
+        expect(Test::EnumTestType.aliases_allowed?).to be false
       end
     end
 

--- a/spec/lib/protobuf/generators/file_generator_spec.rb
+++ b/spec/lib/protobuf/generators/file_generator_spec.rb
@@ -56,10 +56,10 @@ EOF
 require 'protobuf'
 
 module Foo
+  ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
 end
 
 EOF
     end
   end
-
 end

--- a/spec/lib/protobuf/generators/file_generator_spec.rb
+++ b/spec/lib/protobuf/generators/file_generator_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ::Protobuf::Generators::FileGenerator do
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf/message'
+require 'protobuf'
 
 EOF
     end
@@ -53,7 +53,7 @@ EOF
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf/message'
+require 'protobuf'
 
 module Foo
 end

--- a/spec/lib/protobuf/optionable_spec.rb
+++ b/spec/lib/protobuf/optionable_spec.rb
@@ -1,46 +1,169 @@
 require 'spec_helper'
 require 'protobuf/optionable'
+require 'protobuf/field/message_field'
 
 RSpec.describe 'Optionable' do
+  describe '.{get,get!}_option' do
+    before do
+      stub_const("OptionableGetOptionTest", Class.new(::Protobuf::Message) do
+        set_option :deprecated, true
+        set_option :".package.message_field", :field => 33
 
-  describe '.set_option' do
-    before(:all) do
-      OptionableSetOptionTest = ::Class.new do
-        include ::Protobuf::Optionable
-      end
+        optional :int32, :field, 1
+      end)
     end
 
-    it 'stores the given option and value' do
-      expect(OptionableSetOptionTest).to respond_to(:set_option)
-      expect(OptionableSetOptionTest.method(:set_option).arity).to eq(-2)
-      expect do
-        OptionableSetOptionTest.set_option(:foo, :bar)
-      end.to_not raise_error
+    it '.get_option retrieves the option as a symbol' do
+      expect(OptionableGetOptionTest.get_option(:deprecated)).to be(true)
     end
 
-    it 'defaults the value to true' do
-      OptionableSetOptionTest.set_option(:baz_enabled)
-      expect(OptionableSetOptionTest.get_option(:baz_enabled)).to be true
+    it '.get_option returns the default value for unset options' do
+      expect(OptionableGetOptionTest.get_option(:message_set_wire_format)).to be(false)
+    end
+
+    it '.get_option retrieves the option as a string' do
+      expect(OptionableGetOptionTest.get_option('deprecated')).to be(true)
+    end
+
+    it '.get_option errors if the option does not exist' do
+      expect { OptionableGetOptionTest.get_option(:baz) }.to raise_error(ArgumentError)
+    end
+
+    it '.get_option errors if the option is not accessed by its fully qualified name' do
+      message_field = ::Protobuf::Field::MessageField.new(
+        OptionableGetOptionTest, :optional, OptionableGetOptionTest, '.package.message_field', 2, '.message_field', {})
+      allow(::Google::Protobuf::MessageOptions).to receive(:get_field).and_return(message_field)
+      expect { OptionableGetOptionTest.get_option(message_field.name) }.to raise_error(ArgumentError)
+    end
+
+    it '.get_option can return an option representing a message' do
+      message_field = ::Protobuf::Field::MessageField.new(
+        OptionableGetOptionTest, :optional, OptionableGetOptionTest, '.package.message_field', 2, 'message_field', {})
+      allow(::Google::Protobuf::MessageOptions).to receive(:get_field).and_return(message_field)
+      expect(OptionableGetOptionTest.get_option(message_field.fully_qualified_name)).to eq(OptionableGetOptionTest.new(:field => 33))
+    end
+
+    it '.get_option! retrieves explicitly an set option' do
+      expect(OptionableGetOptionTest.get_option!(:deprecated)).to be(true)
+    end
+
+    it '.get_option! returns nil for unset options' do
+      expect(OptionableGetOptionTest.get_option!(:message_set_wire_format)).to be(nil)
+    end
+
+    it '.get_option! errors if the option does not exist' do
+      expect { OptionableGetOptionTest.get_option(:baz) }.to raise_error(ArgumentError)
+    end
+
+    it '#get_option retrieves the option as a symbol' do
+      expect(OptionableGetOptionTest.new.get_option(:deprecated)).to be(true)
+    end
+
+    it '#get_option returns the default value for unset options' do
+      expect(OptionableGetOptionTest.new.get_option(:message_set_wire_format)).to be(false)
+    end
+
+    it '#get_option retrieves the option as a string' do
+      expect(OptionableGetOptionTest.new.get_option('deprecated')).to be(true)
+    end
+
+    it '#get_option errors if the option is not accessed by its fully qualified name' do
+      message_field = ::Protobuf::Field::MessageField.new(
+        OptionableGetOptionTest, :optional, OptionableGetOptionTest, '.package.message_field', 2, 'message_field', {})
+      allow(::Google::Protobuf::MessageOptions).to receive(:get_field).and_return(message_field)
+      expect { OptionableGetOptionTest.new.get_option(message_field.name) }.to raise_error(ArgumentError)
+    end
+
+    it '#get_option can return an option representing a message' do
+      message_field = ::Protobuf::Field::MessageField.new(
+        OptionableGetOptionTest, :optional, OptionableGetOptionTest, '.package.message_field', 2, 'message_field', {})
+      allow(::Google::Protobuf::MessageOptions).to receive(:get_field).and_return(message_field)
+      expect(OptionableGetOptionTest.new.get_option(message_field.fully_qualified_name)).to eq(OptionableGetOptionTest.new(:field => 33))
+    end
+
+    it '#get_option errors if the option does not exist' do
+      expect { OptionableGetOptionTest.new.get_option(:baz) }.to raise_error(ArgumentError)
+    end
+
+    it '#get_option! retrieves explicitly an set option' do
+      expect(OptionableGetOptionTest.new.get_option!(:deprecated)).to be(true)
+    end
+
+    it '#get_option! returns nil for unset options' do
+      expect(OptionableGetOptionTest.new.get_option!(:message_set_wire_format)).to be(nil)
+    end
+
+    it '#get_option! errors if the option does not exist' do
+      expect { OptionableGetOptionTest.new.get_option(:baz) }.to raise_error(ArgumentError)
     end
   end
 
-  describe '.get_option' do
-    before(:all) do
-      OptionableGetOptionTest = ::Class.new do
-        include ::Protobuf::Optionable
-        set_option :foo, :bar
+  describe '.inject' do
+    let(:klass) { Class.new }
+
+    it 'adds klass.{set,get}_option' do
+      expect { klass.get_option(:deprecated) }.to raise_error(NoMethodError)
+      expect { klass.__send__(:set_option, :deprecated, true) }.to raise_error(NoMethodError)
+      ::Protobuf::Optionable.inject(klass) { ::Google::Protobuf::MessageOptions }
+      expect(klass.get_option(:deprecated)).to eq(false)
+      expect { klass.set_option(:deprecated, true) }.to raise_error(NoMethodError)
+      klass.__send__(:set_option, :deprecated, true)
+      expect(klass.get_option(:deprecated)).to eq(true)
+    end
+
+    it 'adds klass#get_option' do
+      expect { klass.new.get_option(:deprecated) }.to raise_error(NoMethodError)
+      ::Protobuf::Optionable.inject(klass) { ::Google::Protobuf::MessageOptions }
+      expect(klass.new.get_option(:deprecated)).to eq(false)
+    end
+
+    it 'adds klass.optionable_descriptor_class' do
+      expect { klass.optionable_descriptor_class }.to raise_error(NoMethodError)
+      ::Protobuf::Optionable.inject(klass) { ::Google::Protobuf::MessageOptions }
+      expect(klass.optionable_descriptor_class).to eq(::Google::Protobuf::MessageOptions)
+    end
+
+    it 'does not add klass.optionable_descriptor_class twice' do
+      expect(klass).to receive(:define_singleton_method).once
+      ::Protobuf::Optionable.inject(klass) { ::Google::Protobuf::MessageOptions }
+      klass.instance_eval do
+        def optionable_descriptor_class
+          ::Google::Protobuf::MessageOptions
+        end
+      end
+      ::Protobuf::Optionable.inject(klass) { ::Google::Protobuf::MessageOptions }
+    end
+
+    it 'throws error when klass.optionable_descriptor_class defined twice with different args' do
+      ::Protobuf::Optionable.inject(klass) { ::Google::Protobuf::MessageOptions }
+      expect { ::Protobuf::Optionable.inject(klass) { ::Google::Protobuf::FileOptions } }
+        .to raise_error('A class is being defined with two different descriptor classes, something is very wrong')
+    end
+
+    context 'extend_class = false' do
+      let(:object) { klass.new }
+      it 'adds object.{get,set}_option' do
+        expect { object.get_option(:deprecated) }.to raise_error(NoMethodError)
+        expect { object.__send__(:set_option, :deprecated, true) }.to raise_error(NoMethodError)
+        ::Protobuf::Optionable.inject(klass, false) { ::Google::Protobuf::MessageOptions }
+        expect(object.get_option(:deprecated)).to eq(false)
+        expect { object.set_option(:deprecated, true) }.to raise_error(NoMethodError)
+        object.__send__(:set_option, :deprecated, true)
+        expect(object.get_option(:deprecated)).to eq(true)
+      end
+
+      it 'does not add klass.{get,set}_option' do
+        expect { object.get_option(:deprecated) }.to raise_error(NoMethodError)
+        ::Protobuf::Optionable.inject(klass, false) { ::Google::Protobuf::MessageOptions }
+        expect { klass.get_option(:deprecated) }.to raise_error(NoMethodError)
+        expect { klass.__send__(:set_option, :deprecated) }.to raise_error(NoMethodError)
+      end
+
+      it 'creates an instance method optionable_descriptor_class' do
+        expect { object.optionable_descriptor_class }.to raise_error(NoMethodError)
+        ::Protobuf::Optionable.inject(klass, false) { ::Google::Protobuf::MessageOptions }
+        expect(object.optionable_descriptor_class).to eq(::Google::Protobuf::MessageOptions)
       end
     end
-
-    it 'retrieves the option for the given name, if any' do
-      expect(OptionableGetOptionTest.get_option(:foo)).to eq(:bar)
-      expect(OptionableGetOptionTest.get_option(:baz)).to be_nil
-    end
-
-    it 'retrieves the option in the context of an instance' do
-      expect(OptionableGetOptionTest.new.get_option(:foo)).to eq(:bar)
-      expect(OptionableGetOptionTest.new.get_option(:baz)).to be_nil
-    end
   end
-
 end

--- a/spec/support/protos/enum.pb.rb
+++ b/spec/support/protos/enum.pb.rb
@@ -12,6 +12,7 @@ require 'protobuf'
 require 'protos/resource.pb'
 
 module Test
+  ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
 
   ##
   # Enum Classes

--- a/spec/support/protos/enum.pb.rb
+++ b/spec/support/protos/enum.pb.rb
@@ -3,7 +3,7 @@
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf/message'
+require 'protobuf'
 
 
 ##

--- a/spec/support/protos/google_unittest.pb.rb
+++ b/spec/support/protos/google_unittest.pb.rb
@@ -13,6 +13,7 @@ require 'protobuf/rpc/service'
 require 'protos/google_unittest_import.pb'
 
 module Protobuf_unittest
+  ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
 
   ##
   # Enum Classes

--- a/spec/support/protos/google_unittest.pb.rb
+++ b/spec/support/protos/google_unittest.pb.rb
@@ -3,7 +3,7 @@
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf/message'
+require 'protobuf'
 require 'protobuf/rpc/service'
 
 

--- a/spec/support/protos/google_unittest_import.pb.rb
+++ b/spec/support/protos/google_unittest_import.pb.rb
@@ -12,6 +12,7 @@ require 'protobuf'
 require 'protos/google_unittest_import_public.pb'
 
 module Protobuf_unittest_import
+  ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
 
   ##
   # Enum Classes

--- a/spec/support/protos/google_unittest_import.pb.rb
+++ b/spec/support/protos/google_unittest_import.pb.rb
@@ -3,7 +3,7 @@
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf/message'
+require 'protobuf'
 
 
 ##

--- a/spec/support/protos/google_unittest_import_public.pb.rb
+++ b/spec/support/protos/google_unittest_import_public.pb.rb
@@ -3,7 +3,7 @@
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf/message'
+require 'protobuf'
 
 module Protobuf_unittest_import
 

--- a/spec/support/protos/google_unittest_import_public.pb.rb
+++ b/spec/support/protos/google_unittest_import_public.pb.rb
@@ -6,6 +6,7 @@
 require 'protobuf'
 
 module Protobuf_unittest_import
+  ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
 
   ##
   # Message Classes

--- a/spec/support/protos/multi_field_extensions.pb.rb
+++ b/spec/support/protos/multi_field_extensions.pb.rb
@@ -6,6 +6,7 @@
 require 'protobuf'
 
 module Test
+  ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
 
   ##
   # Message Classes

--- a/spec/support/protos/multi_field_extensions.pb.rb
+++ b/spec/support/protos/multi_field_extensions.pb.rb
@@ -3,7 +3,7 @@
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf/message'
+require 'protobuf'
 
 module Test
 

--- a/spec/support/protos/resource.pb.rb
+++ b/spec/support/protos/resource.pb.rb
@@ -3,7 +3,7 @@
 ##
 # This file is auto-generated. DO NOT EDIT!
 #
-require 'protobuf/message'
+require 'protobuf'
 require 'protobuf/rpc/service'
 
 module Test

--- a/spec/support/protos/resource.pb.rb
+++ b/spec/support/protos/resource.pb.rb
@@ -7,6 +7,7 @@ require 'protobuf'
 require 'protobuf/rpc/service'
 
 module Test
+  ::Protobuf::Optionable.inject(self) { ::Google::Protobuf::FileOptions }
 
   ##
   # Enum Classes


### PR DESCRIPTION
In prep for adding support for custom field, enum, message, file, service, and method options

CC @nerdrew @film42 @liveh2o 

Re: requires

`get_option` needs Google::Protobuf::*Options to work (Optionable takes
a Google::Protobuf::*Options class as an argument), so descriptor.pb
needs to get required before using `get_option`.

BUT, to parse descriptor.pb, Protobuf::{Enum,Message,etc} needs to
exist. So, require protobuf/message, then require descriptor.pb

get_option! -> return explicitly set options only