### PR TITLE
Fix rubocop: lock down the parser version / upgrade rubocop to 0.35

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  DisplayCopNames: true
+
 Lint/EndAlignment:
   AlignWith: keyword
 

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -27,7 +27,8 @@ require "protobuf/version"
   s.add_development_dependency 'ffi-rzmq'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3.0'
-  s.add_development_dependency 'rubocop', '0.34.2'
+  s.add_development_dependency "rubocop", "~> 0.35.0"
+  s.add_development_dependency "parser", "2.3.0.6" # Locked this down since 2.3.0.7 causes issues. https://github.com/bbatsov/rubocop/pull/2984
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'yard'

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Protobuf::Enum do
             Test::EnumTestType::TWO,
             Test::EnumTestType::MINUS_ONE,
             Test::EnumTestType::THREE,
-          ],
+          ]
         )
       end
 
@@ -68,7 +68,7 @@ RSpec.describe Protobuf::Enum do
               EnumAliasTest::FOO,
               EnumAliasTest::BAR,
               EnumAliasTest::BAZ,
-            ],
+            ]
           )
         end
       end

--- a/spec/lib/protobuf/rpc/service_filters_spec.rb
+++ b/spec/lib/protobuf/rpc/service_filters_spec.rb
@@ -362,7 +362,7 @@ RSpec.describe Protobuf::Rpc::ServiceFilters do
           :endpoint,
           :inner_around_bottom,
           :outer_around_bottom,
-        ],
+        ]
       )
     end
 
@@ -390,7 +390,7 @@ RSpec.describe Protobuf::Rpc::ServiceFilters do
             :outer_around_top,
             :inner_around,
             :outer_around_bottom,
-          ],
+          ]
         )
       end
 

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -31,7 +31,7 @@ class StubServer
         :worker_port => 9400,
         :delay => 0,
         :server => Protobuf::Rpc::Socket::Server,
-      ),
+      )
     )
 
     start


### PR DESCRIPTION
This should fix rubocop. I locked down the parser version and had to upgrade rubocop in order to make things work again. There was a new cop added, but I like the change so I kept it enabled.

cc @brianstien @embark @mmmries @liveh2o @abrandoned 