### PR TITLE
Revert to old behavior for setting repeated fields to nil

### DIFF
--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -185,7 +185,7 @@ module Protobuf
 
         message_class.class_eval do
           define_method(simple_field_name) { self[fully_qualified_field_name] }
-          define_method("#{simple_field_name}=") { |v| self[fully_qualified_field_name] = v }
+          define_method("#{simple_field_name}=") { |v| set_field(fully_qualified_field_name, v, false) }
         end
 
         return unless deprecated?

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -41,7 +41,7 @@ module Protobuf
     def initialize(fields = {})
       @values = {}
       fields.to_hash.each do |name, value|
-        self[name] = value
+        set_field(name, value, true)
       end
 
       yield self if block_given?
@@ -163,8 +163,37 @@ module Protobuf
     end
 
     def []=(name, value)
+      set_field(name, value, true)
+    end
+
+    ##
+    # Instance Aliases
+    #
+    alias_method :to_hash_value, :to_hash
+    alias_method :to_proto_hash, :to_hash
+    alias_method :responds_to_has?, :respond_to_has?
+    alias_method :respond_to_and_has?, :respond_to_has?
+    alias_method :responds_to_and_has?, :respond_to_has?
+    alias_method :respond_to_has_present?, :respond_to_has_and_present?
+    alias_method :respond_to_and_has_present?, :respond_to_has_and_present?
+    alias_method :respond_to_and_has_and_present?, :respond_to_has_and_present?
+    alias_method :responds_to_has_present?, :respond_to_has_and_present?
+    alias_method :responds_to_and_has_present?, :respond_to_has_and_present?
+    alias_method :responds_to_and_has_and_present?, :respond_to_has_and_present?
+
+    ##
+    # Private Instance Methods
+    #
+
+    private
+
+    def set_field(name, value, ignore_nil_for_repeated)
       if (field = self.class.get_field(name, true))
         if field.repeated?
+          if value.nil? && ignore_nil_for_repeated
+            ::Protobuf.deprecator.deprecation_warning("#{self.class}#[#{name}]=nil", "use an empty array instead of nil")
+            return
+          end
           if value.is_a?(Array)
             value = value.compact
           else
@@ -195,27 +224,6 @@ module Protobuf
         end
       end
     end
-
-    ##
-    # Instance Aliases
-    #
-    alias_method :to_hash_value, :to_hash
-    alias_method :to_proto_hash, :to_hash
-    alias_method :responds_to_has?, :respond_to_has?
-    alias_method :respond_to_and_has?, :respond_to_has?
-    alias_method :responds_to_and_has?, :respond_to_has?
-    alias_method :respond_to_has_present?, :respond_to_has_and_present?
-    alias_method :respond_to_and_has_present?, :respond_to_has_and_present?
-    alias_method :respond_to_and_has_and_present?, :respond_to_has_and_present?
-    alias_method :responds_to_has_present?, :respond_to_has_and_present?
-    alias_method :responds_to_and_has_present?, :respond_to_has_and_present?
-    alias_method :responds_to_and_has_and_present?, :respond_to_has_and_present?
-
-    ##
-    # Private Instance Methods
-    #
-
-    private
 
     def copy_to(object, method)
       duplicate = proc do |obj|

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -181,6 +181,12 @@ RSpec.describe Protobuf::Message do
       test_enum = Test::EnumTestMessage.new { |p| p.non_default_enum = 2 }
       expect(test_enum.non_default_enum).to eq(2)
     end
+
+    # to be deprecated
+    it "allows you to pass nil to repeated fields" do
+      test = Test::Resource.new(:repeated_enum => nil)
+      expect(test.repeated_enum).to eq([])
+    end
   end
 
   describe '#encode' do
@@ -442,6 +448,10 @@ RSpec.describe Protobuf::Message do
 
     it 'does not allow string fields to be set to Numeric' do
       expect { subject.name = 1 }.to raise_error(/name/)
+    end
+
+    it 'does not allow a repeated field is set to nil' do
+      expect { subject.repeated_enum = nil }.to raise_error(TypeError)
     end
 
     context '#{simple_field_name}!' do
@@ -722,6 +732,17 @@ RSpec.describe Protobuf::Message do
         expect(instance[:ext_is_searchable]).to eq(false)
         instance[100] = true
         expect(instance[:ext_is_searchable]).to eq(true)
+      end
+
+      # to be deprecated
+      it 'does nothing when sent an empty array' do
+        instance[:repeated_enum] = nil
+        expect(instance[:repeated_enum]).to eq([])
+        instance[:repeated_enum] = [1, 2]
+        expect(instance[:repeated_enum]).to eq([1, 2])
+        instance[:repeated_enum] = nil
+        # Yes this is very silly, but backwards compatible
+        expect(instance[:repeated_enum]).to eq([1, 2])
       end
     end
 


### PR DESCRIPTION
The direct setter for repeated fields didn't allow nil values, but everything else did (and ignored nils). We accidentally changed that behavior, even though it's awful behavior and should probably be intentionally changed in the future.

CC @nerdrew @film42 @zachmargolis 

Sorry about the breaking changes :/