### PR TITLE
Allow user defined service directories

### DIFF
--- a/lib/protobuf/rpc/connectors/zmq.rb
+++ b/lib/protobuf/rpc/connectors/zmq.rb
@@ -226,7 +226,7 @@ module Protobuf
 
         # Alias for ::Protobuf::Rpc::ServiceDirectory.instance
         def service_directory
-          ::Protobuf::Rpc::ServiceDirectory.instance
+          ::Protobuf::Rpc.service_directory
         end
 
         def snd_timeout

--- a/lib/protobuf/rpc/service_directory.rb
+++ b/lib/protobuf/rpc/service_directory.rb
@@ -9,6 +9,14 @@ require 'protobuf/rpc/dynamic_discovery.pb'
 
 module Protobuf
   module Rpc
+    def self.service_directory
+      @service_directory ||= ::Protobuf::Rpc::ServiceDirectory.instance
+    end
+
+    def self.service_directory=(directory)
+      @service_directory = directory
+    end
+
     class ServiceDirectory
       include ::Singleton
       include ::Protobuf::Logging


### PR DESCRIPTION
Currently, ZMQ assumes that UDP broadcast based service discovery will
fit all needs. This change allows a user to create their own service
directory and plug it into the ZMQ connector.