### PR TITLE
upcase enums during default value generation

### DIFF
--- a/lib/protobuf/generators/field_generator.rb
+++ b/lib/protobuf/generators/field_generator.rb
@@ -108,7 +108,13 @@ module Protobuf
       private
 
       def enum_default_value
-        "#{type_name}::#{verbatim_default_value}"
+        optionally_upcased_default =
+          if ENV.key?('PB_UPCASE_ENUMS')
+            verbatim_default_value.upcase
+          else
+            verbatim_default_value
+          end
+        "#{type_name}::#{optionally_upcased_default}"
       end
 
       def float_double_default_value


### PR DESCRIPTION
This is an enhancement to #285.

Some of my proto definitions set a starts-with-lowercase enum value as an optional field's default, resulting in problematic code gen.

I'm sorry for the lack of test--if I have a bit more time I'll try to write one. I just want to bring the issue up.
