### PR TITLE
Evaluate extension fields in code generation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,11 +56,8 @@ Style/TrailingBlankLines:
   Exclude:
     - '**/*.pb.rb'
 
-Style/TrailingCommaInLiteral:
+Style/TrailingComma:
   EnforcedStyleForMultiline: comma
-
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: no_comma
 
 Style/TrivialAccessors:
   AllowDSLWriters: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,8 +56,11 @@ Style/TrailingBlankLines:
   Exclude:
     - '**/*.pb.rb'
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
 
 Style/TrivialAccessors:
   AllowDSLWriters: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libzmq3-dev
   - sudo -E ./install-protobuf.sh
+  # Required for rainbow installation issue, https://github.com/sickill/rainbow/issues/44
+  - gem update --system
   - gem update bundler
 language: ruby
 rvm:

--- a/bin/protoc-gen-ruby
+++ b/bin/protoc-gen-ruby
@@ -18,5 +18,5 @@ STDOUT.binmode
 
 request_bytes = STDIN.read
 code_generator = ::Protobuf::CodeGenerator.new(request_bytes)
-response_bytes = code_generator.response_bytes
-STDOUT.print(response_bytes)
+code_generator.eval_unknown_extensions!
+STDOUT.print(code_generator.response_bytes)

--- a/lib/protobuf/code_generator.rb
+++ b/lib/protobuf/code_generator.rb
@@ -25,7 +25,15 @@ module Protobuf
     public
 
     def initialize(request_bytes)
+      @request_bytes = request_bytes
       self.request = ::Google::Protobuf::Compiler::CodeGeneratorRequest.decode(request_bytes)
+    end
+
+    def eval_unknown_extensions!
+      request.proto_file.each do |file_descriptor|
+        ::Protobuf::Generators::FileGenerator.new(file_descriptor).eval_unknown_extensions!
+      end
+      self.request = ::Google::Protobuf::Compiler::CodeGeneratorRequest.decode(@request_bytes)
     end
 
     def generate_file(file_descriptor)

--- a/lib/protobuf/generators/file_generator.rb
+++ b/lib/protobuf/generators/file_generator.rb
@@ -243,10 +243,11 @@ module Protobuf
         @io.rewind
       end
 
-      def create_ruby_namespace_heiarchy(name)
-        i = name.size
-        while (i = name[0...i].rindex(".")) && i > 0
-          eval_dependencies(name[0...i])
+      def create_ruby_namespace_heiarchy(namespace)
+        loop do
+          namespace, _match, _tail = namespace.rpartition(".")
+          break if namespace.empty?
+          eval_dependencies(namespace)
         end
       end
 

--- a/lib/protobuf/generators/file_generator.rb
+++ b/lib/protobuf/generators/file_generator.rb
@@ -218,7 +218,7 @@ module Protobuf
           eval_enum_code(enum, namespace[0..-2].join("."))
           @evaled_dependencies << name
         else
-          raise "Error loading unknown dependencies, could not find message or enum #{name.inspect}"
+          fail "Error loading unknown dependencies, could not find message or enum #{name.inspect}"
         end
       end
 

--- a/lib/protobuf/generators/group_generator.rb
+++ b/lib/protobuf/generators/group_generator.rb
@@ -32,8 +32,9 @@ module Protobuf
         @comments[type] = message
       end
 
-      def add_extended_messages(extended_messages)
+      def add_extended_messages(extended_messages, skip_empty_fields = true)
         extended_messages.each do |message_type, field_descriptors|
+          next if skip_empty_fields && field_descriptors.empty?
           @groups[:extended_message] << ExtensionGenerator.new(message_type, field_descriptors, indent_level)
         end
       end

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -27,7 +27,7 @@ require "protobuf/version"
   s.add_dependency 'thread_safe'
 
   s.add_development_dependency 'ffi-rzmq'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '< 11.0' # Rake 11.0.1 removes the last_comment method which rspec-core (< 3.4.4) uses
   s.add_development_dependency 'rspec', '>= 3.0'
   s.add_development_dependency "rubocop", "~> 0.35.0"
   s.add_development_dependency "parser", "2.3.0.6" # Locked this down since 2.3.0.7 causes issues. https://github.com/bbatsov/rubocop/pull/2984


### PR DESCRIPTION
This is necessary to access descriptor extensions during code generation. In other PRs, I'll use these "loaded" extension classes later in the code generation to enable custom options.

CC @film42 @liveh2o @nerdrew @zachmargolis 

This one is a little gnarly, but should be the most complicated PR in this series fast followed by the remaining ones.
