### PR TITLE
Log error in run loop before teardown to pevent freezing without error

### DIFF
--- a/lib/protobuf/rpc/servers/zmq/server.rb
+++ b/lib/protobuf/rpc/servers/zmq/server.rb
@@ -185,6 +185,19 @@ module Protobuf
           broadcast_flatline if broadcast_beacons?
           Thread.pass until reap_dead_workers.empty?
           @broker_thread.join unless brokerless?
+        rescue => error
+          logger.error { sign_message(error) }
+
+          if error.respond_to?(:backtrace)
+            backtrace = [error.backtrace].flatten
+            backtrace.each do |line|
+              logger.error { sign_message(line) }
+            end
+          else
+            logger.error { sign_message("No backtrace was provided with this error") }
+          end
+
+          raise error
         ensure
           @running = false
           teardown


### PR DESCRIPTION
It's possible for the teardown call to fire and wait on workers to
finish (which might never finish). In this case, we're never going to
see this error. To combat this, we can log the error before the ensure
block is executed. The fact that we found this code path means that
someone is not handing an error further down. But until we know which
error we're missing, we can't fix it.

The only downside is that this will double log errors if we raise them after the run loop, which I think is the right thing to do. Here's an example of what I mean:

```
protobuf (gt/run_loop_logging*) $ zmq derp bx rpc_server --threads=80 --broadcast-beacons --zmq-inproc --host=0.0.0.0 --port=30000 /tmp/env.rb
Loading env...
I, [2016-07-05T10:58:58.295056 #25712]  INFO -- : pid 25712 -- zmq RPC Server listening at 0.0.0.0:30000
E, [2016-07-05T11:05:31.081957 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] testing
E, [2016-07-05T11:05:31.082057 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/Development/RubyDevelopment/protobuf/lib/protobuf/rpc/servers/zmq/server.rb:182:in `run'
E, [2016-07-05T11:05:31.082105 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/Development/RubyDevelopment/protobuf/lib/protobuf/rpc/servers/zmq_runner.rb:23:in `run'
E, [2016-07-05T11:05:31.082129 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/Development/RubyDevelopment/protobuf/lib/protobuf/cli.rb:231:in `start_server'
E, [2016-07-05T11:05:31.082150 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/Development/RubyDevelopment/protobuf/lib/protobuf/cli.rb:60:in `start'
E, [2016-07-05T11:05:31.082170 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
E, [2016-07-05T11:05:31.082278 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
E, [2016-07-05T11:05:31.082307 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
E, [2016-07-05T11:05:31.082327 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
E, [2016-07-05T11:05:31.082352 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/Development/RubyDevelopment/protobuf/bin/rpc_server:4:in `<top (required)>'
E, [2016-07-05T11:05:31.082388 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rpc_server:23:in `load'
E, [2016-07-05T11:05:31.082431 #27747] ERROR -- : [server-Protobuf::Rpc::Zmq::Server-70312936010520] /Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rpc_server:23:in `<main>'
E, [2016-07-05T11:05:33.088368 #27747] ERROR -- : ERROR: RPC Server failed to start.
[RuntimeError] testing
/Users/film42/Development/RubyDevelopment/protobuf/lib/protobuf/rpc/servers/zmq/server.rb:182:in `run'
/Users/film42/Development/RubyDevelopment/protobuf/lib/protobuf/rpc/servers/zmq_runner.rb:23:in `run'
/Users/film42/Development/RubyDevelopment/protobuf/lib/protobuf/cli.rb:231:in `start_server'
/Users/film42/Development/RubyDevelopment/protobuf/lib/protobuf/cli.rb:60:in `start'
/Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
/Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
/Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
/Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
/Users/film42/Development/RubyDevelopment/protobuf/bin/rpc_server:4:in `<top (required)>'
/Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rpc_server:23:in `load'
/Users/film42/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/bin/rpc_server:23:in `<main>'
E, [2016-07-05T11:05:33.088910 #27747] ERROR -- : [RuntimeError] testing
```

cc @brianstien 
