### PR TITLE
Change the ping port to use ms timeout and make the default 200ms

### DIFF
--- a/lib/protobuf/rpc/connectors/ping.rb
+++ b/lib/protobuf/rpc/connectors/ping.rb
@@ -29,9 +29,9 @@ module Protobuf
         def timeout
           @timeout ||= begin
             if ::ENV.key?("PB_RPC_PING_PORT_TIMEOUT")
-              ::ENV["PB_RPC_PING_PORT_TIMEOUT"].to_i
+              ::ENV["PB_RPC_PING_PORT_TIMEOUT"].to_f / 1000
             else
-              5 # 5 seconds
+              0.2 # 200 ms
             end
           end
         end

--- a/spec/lib/protobuf/rpc/connectors/ping_spec.rb
+++ b/spec/lib/protobuf/rpc/connectors/ping_spec.rb
@@ -55,14 +55,14 @@ require "protobuf/zmq"
 
   describe "#timeout" do
     it "uses the default value" do
-      expect(subject.timeout).to eq(5)
+      expect(subject.timeout).to eq(0.2)
     end
 
     context "when environment variable is set" do
-      before { ::ENV["PB_RPC_PING_PORT_TIMEOUT"] = "1" }
+      before { ::ENV["PB_RPC_PING_PORT_TIMEOUT"] = "100" }
 
       it "uses the environmet variable" do
-        expect(subject.timeout).to eq(1)
+        expect(subject.timeout).to eq(0.1)
       end
     end
   end


### PR DESCRIPTION
Specs are passing locally. Rubocop will fail in this branch.

cc @abrandoned @quixoten 