### PR TITLE
Remove superfluous rescue from service dispatcher

### DIFF
--- a/lib/protobuf/rpc/service_dispatcher.rb
+++ b/lib/protobuf/rpc/service_dispatcher.rb
@@ -28,12 +28,9 @@ module Protobuf
 
       private
 
-      # Call the given service method.
       def dispatch_rpc_request
         rpc_service.call(method_name)
         rpc_service.response
-      rescue NoMethodError
-        raise MethodNotFound, "#{service_name}##{method_name} is not a defined RPC method."
       end
 
       def method_name

--- a/spec/lib/protobuf/rpc/service_dispatcher_spec.rb
+++ b/spec/lib/protobuf/rpc/service_dispatcher_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Protobuf::Rpc::ServiceDispatcher do
   let(:request_type) { service_class.rpcs[method_name].request_type }
   let(:response) { response_type.new(:name => 'required') }
   let(:response_type) { service_class.rpcs[method_name].response_type }
-
   let(:rpc_service) { service_class.new(env) }
   let(:service_class) { Test::ResourceService }
   let(:service_name) { service_class.to_s }
@@ -31,22 +30,6 @@ RSpec.describe Protobuf::Rpc::ServiceDispatcher do
     it "dispatches the request" do
       stack_env = subject._call(env)
       expect(stack_env.response).to eq response
-    end
-
-    context "when the given RPC method is not implemented" do
-      let(:method_name) { :find_not_implemented }
-
-      it "raises a method not found exception" do
-        expect { subject.call(env) }.to raise_exception(Protobuf::Rpc::MethodNotFound)
-      end
-    end
-
-    context "when the given RPC method is implemented and a NoMethodError is raised" do
-      before { allow(rpc_service).to receive(:call).and_raise(NoMethodError) }
-
-      it "raises the exeception" do
-        expect { subject.call(env) }.to raise_exception(Protobuf::Rpc::MethodNotFound)
-      end
     end
   end
 end


### PR DESCRIPTION
Likely a relic of pre-middleware days, the service dispatcher was rescuing all `NoMethodError` exceptions and re-raising it's own `MethodNotFound` exception. The request decoder middleware now handles this case, and it was way too broad (i.e. it was masking actual `NoMethodError` exceptions), so it has been removed.

// @abrandoned @film42 