### PR TITLE
Set maximum version to activesupport gem

### DIFF
--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -19,7 +19,7 @@ require "protobuf/version"
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport', '>= 3.2'
+  s.add_dependency 'activesupport', '>= 3.2', '< 5'
   s.add_dependency 'middleware'
   s.add_dependency 'thor'
   s.add_dependency 'thread_safe'


### PR DESCRIPTION
Not setting activesupport maximum version will install version 5, which only supports Ruby >= 2.2.2 (released in April 2015). This pull request will currently make bundle install activesupport 4.2.7.1, which also works on  Ruby >= 1.9.3.