### PR TITLE
Read and write with delimiters

### DIFF
--- a/lib/protobuf/message/serialization.rb
+++ b/lib/protobuf/message/serialization.rb
@@ -14,6 +14,10 @@ module Protobuf
         def decode_from(stream)
           new.decode_from(stream)
         end
+        
+        def decode_delimited_from(stream)
+          new.decode_delimited_from(stream)
+        end
 
         # Create a new object with the given values and return the encoded bytes.
         def encode(fields = {})
@@ -33,6 +37,14 @@ module Protobuf
       #
       def decode(bytes)
         decode_from(::StringIO.new(bytes))
+      end
+
+      # Decode message from delimited stream (same as parseDelimitedFrom from Java)
+      #
+      def decode_delimited_from(stream)
+        length = ::Protobuf::Varint.decode(stream)
+        byte_data = stream.read(length)
+        decode(byte_data)
       end
 
       # Decode the given stream into this message.
@@ -58,6 +70,14 @@ module Protobuf
       #
       def encode_to(stream)
         ::Protobuf::Encoder.encode(self, stream)
+      end
+
+      # Encode this message to the given stream with length prefix
+      # (same as writeDelimitedTo from java)
+      #
+      def encode_delimited_to(stream)
+        byte_data = encode
+        stream << "#{::Protobuf::Field::VarintField.encode(byte_data.size)}#{byte_data}"
       end
 
       ##

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -74,6 +74,22 @@ RSpec.describe Protobuf::Message do
     end
   end
 
+  describe 'delimited input/output' do
+    let(:message1) { ::Test::Resource.new(:name => "Jim") }
+    let(:message2) { ::Test::Resource.new(:name => "Kirk") }
+
+    it 'writes two delimited messages to stream and then reads them' do
+      stream = ::StringIO.new
+      message1.encode_delimited_to(stream)
+      message2.encode_delimited_to(stream)
+      stream.rewind
+      readed_message1 = ::Test::Resource.decode_delimited_from(stream)
+      readed_message2 = ::Test::Resource.decode_delimited_from(stream)
+      expect(readed_message1).to eq message1
+      expect(readed_message2).to eq message2
+    end
+  end
+
   describe '.decode_from' do
     let(:message) { ::Test::Resource.new(:name => "Jim") }
 


### PR DESCRIPTION
Added functions for writing and reading messages with length delimiters.

`encode_delimited_to` - encodes message to stream with length prefix. Analogue to https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/MessageLite.html#writeDelimitedTo-java.io.OutputStream-
`decode_delimited_from` - reads from stream, created with previous function. Analogue to https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/AbstractParser.html#parseDelimitedFrom-java.io.InputStream-