### PR TITLE
Fix decoding of packed fields

### DIFF
--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -129,11 +129,11 @@ module Protobuf
         stream = StringIO.new(bytes)
 
         if wire_type == ::Protobuf::WireType::VARINT
-          array << Varint.decode(stream) until stream.eof?
+          array << decode(Varint.decode(stream)) until stream.eof?
         elsif wire_type == ::Protobuf::WireType::FIXED64
-          array << stream.read(8) until stream.eof?
+          array << decode(stream.read(8)) until stream.eof?
         elsif wire_type == ::Protobuf::WireType::FIXED32
-          array << stream.read(4) until stream.eof?
+          array << decode(stream.read(4)) until stream.eof?
         end
       end
 

--- a/spec/lib/protobuf/field/bool_field_spec.rb
+++ b/spec/lib/protobuf/field/bool_field_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 RSpec.describe Protobuf::Field::BoolField do
 
+  it_behaves_like :packable_field, described_class do
+    let(:value) { [true, false] }
+  end
+
   class SomeBoolMessage < ::Protobuf::Message
     optional :bool, :some_bool, 1
     required :bool, :required_bool, 2

--- a/spec/lib/protobuf/field/double_field_spec.rb
+++ b/spec/lib/protobuf/field/double_field_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::DoubleField do
+
+  it_behaves_like :packable_field, described_class do
+    let(:value) { [1.0, 2.0, 3.0] }
+  end
+
+end

--- a/spec/lib/protobuf/field/fixed32_field_spec.rb
+++ b/spec/lib/protobuf/field/fixed32_field_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::Fixed32Field do
+
+  it_behaves_like :packable_field, described_class
+
+end

--- a/spec/lib/protobuf/field/fixed64_field_spec.rb
+++ b/spec/lib/protobuf/field/fixed64_field_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::Fixed64Field do
+
+  it_behaves_like :packable_field, described_class
+
+end

--- a/spec/lib/protobuf/field/float_field_spec.rb
+++ b/spec/lib/protobuf/field/float_field_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 RSpec.describe Protobuf::Field::FloatField do
 
+  it_behaves_like :packable_field, described_class do
+    let(:value) { [1.0, 2.0, 3.0] }
+  end
+
   class SomeFloatMessage < ::Protobuf::Message
     optional :float, :some_float, 1
   end

--- a/spec/lib/protobuf/field/int64_field_spec.rb
+++ b/spec/lib/protobuf/field/int64_field_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::Int64Field do
+
+  it_behaves_like :packable_field, described_class
+
+end

--- a/spec/lib/protobuf/field/sfixed32_field_spec.rb
+++ b/spec/lib/protobuf/field/sfixed32_field_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::Sfixed32Field do
+
+  it_behaves_like :packable_field, described_class do
+    let(:value) { [-1, 0, 1] }
+  end
+
+end

--- a/spec/lib/protobuf/field/sfixed64_field_spec.rb
+++ b/spec/lib/protobuf/field/sfixed64_field_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::Sfixed64Field do
+
+  it_behaves_like :packable_field, described_class do
+    let(:value) { [-1, 0, 1] }
+  end
+
+end

--- a/spec/lib/protobuf/field/sint32_field_spec.rb
+++ b/spec/lib/protobuf/field/sint32_field_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::Sint32Field do
+
+  it_behaves_like :packable_field, described_class do
+    let(:value) { [-1, 0, 1] }
+  end
+
+end

--- a/spec/lib/protobuf/field/sint64_field_spec.rb
+++ b/spec/lib/protobuf/field/sint64_field_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::Sint64Field do
+
+  it_behaves_like :packable_field, described_class do
+    let(:value) { [-1, 0, 1] }
+  end
+
+end

--- a/spec/lib/protobuf/field/uint32_field_spec.rb
+++ b/spec/lib/protobuf/field/uint32_field_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::Uint32Field do
+
+  it_behaves_like :packable_field, described_class
+
+end

--- a/spec/lib/protobuf/field/uint64_field_spec.rb
+++ b/spec/lib/protobuf/field/uint64_field_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Protobuf::Field::Uint64Field do
+
+  it_behaves_like :packable_field, described_class
+
+end

--- a/spec/support/packed_field.rb
+++ b/spec/support/packed_field.rb
@@ -12,11 +12,12 @@ if defined?(RSpec)
     end
 
     let(:field_name) { "#{field_klass.name.split('::').last.underscore}_packed_field".to_sym }
-    let(:message_instance) { PackableFieldTest.new(field_name => [100, 200, 300]) }
+    let(:value) { [100, 200, 300] }
+    let(:message_instance) { PackableFieldTest.new(field_name => value) }
 
     subject { PackableFieldTest.get_field(field_name) }
 
     specify { expect(subject).to be_packed }
-
+    specify { expect(PackableFieldTest.decode(message_instance.encode).send(field_name)).to eq value }
   end
 end


### PR DESCRIPTION
Packed repeated field is currently not decoded by #decode of its own class.
The value should be decoded after reading it.