### PR TITLE
Bugfix: enum_for_tags returns nil if tag nil

### DIFF
--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -94,7 +94,7 @@ module Protobuf
     # Returns an array with zero or more Enum objects or nil.
     #
     def self.enums_for_tag(tag)
-      mapped_enums[tag.to_i] || []
+      tag && mapped_enums[tag.to_i] || []
     end
 
     # Public: Get the Enum associated with the given name.
@@ -129,7 +129,7 @@ module Protobuf
     #   Enums, the first enum defined will be returned.
     #
     def self.enum_for_tag(tag)
-      (mapped_enums[tag.to_i] || []).first
+      tag && (mapped_enums[tag.to_i] || []).first
     end
 
     # Public: Get an Enum by a variety of type-checking mechanisms.

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Protobuf::Enum do
       it 'provides an array of defined Enums' do
         expect(Test::EnumTestType.enums).to eq(
           [
+            Test::EnumTestType::ZERO,
             Test::EnumTestType::ONE,
             Test::EnumTestType::TWO,
             Test::EnumTestType::MINUS_ONE,
@@ -76,6 +77,7 @@ RSpec.describe Protobuf::Enum do
 
     describe '.enums_for_tag' do
       it 'returns an array of Enums for the given tag, if any' do
+        expect(EnumAliasTest.enums_for_tag(nil)).to eq([])
         expect(EnumAliasTest.enums_for_tag(1)).to eq([EnumAliasTest::FOO, EnumAliasTest::BAR])
         expect(EnumAliasTest.enums_for_tag(2)).to eq([EnumAliasTest::BAZ])
         expect(EnumAliasTest.enums_for_tag(3)).to eq([])
@@ -124,6 +126,7 @@ RSpec.describe Protobuf::Enum do
       it 'gets the Enum corresponding to the given tag' do
         expect(Test::EnumTestType.enum_for_tag(tag)).to eq(Test::EnumTestType.const_get(name))
         expect(Test::EnumTestType.enum_for_tag(-5)).to be_nil
+        expect(Test::EnumTestType.enum_for_tag(nil)).to be_nil
       end
     end
 
@@ -186,6 +189,7 @@ RSpec.describe Protobuf::Enum do
       it 'provides a hash of defined Enums' do
         expect(Test::EnumTestType.values).to eq(
           :MINUS_ONE => Test::EnumTestType::MINUS_ONE,
+          :ZERO      => Test::EnumTestType::ZERO,
           :ONE       => Test::EnumTestType::ONE,
           :TWO       => Test::EnumTestType::TWO,
           :THREE     => Test::EnumTestType::THREE,

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -142,12 +142,12 @@ RSpec.describe Protobuf::Message do
   describe '#initialize' do
     it "defaults to the first value listed in the enum's type definition" do
       test_enum = Test::EnumTestMessage.new
-      expect(test_enum.non_default_enum).to eq(1)
+      expect(test_enum.non_default_enum).to eq(Test::EnumTestType.enums.first)
     end
 
     it "defaults to a a value with a name" do
       test_enum = Test::EnumTestMessage.new
-      expect(test_enum.non_default_enum.name).to eq(:ONE)
+      expect(test_enum.non_default_enum.name).to eq(Test::EnumTestType.enums.first.name)
     end
 
     it "exposes the enum getter raw value through ! method" do

--- a/spec/support/protos/enum.pb.rb
+++ b/spec/support/protos/enum.pb.rb
@@ -18,6 +18,7 @@ module Test
   # Enum Classes
   #
   class EnumTestType < ::Protobuf::Enum
+    define :ZERO, 0
     define :ONE, 1
     define :TWO, 2
   end

--- a/spec/support/protos/enum.proto
+++ b/spec/support/protos/enum.proto
@@ -6,6 +6,7 @@ import 'protos/resource.proto';
 // Test extending another message from an imported file.
 
 enum EnumTestType {
+  ZERO = 0;
   ONE = 1;
   TWO = 2;
 }


### PR DESCRIPTION
This fixes https://github.com/ruby-protobuf/protobuf/issues/265
Bug: calling to_i on nil returns 0, and so will return an erroneous
value if the enum is zero-indexed.