### PR TITLE
acceptable check is not needed most places as coerce runs the same lo…

### DIFF
--- a/lib/protobuf/field/bool_field.rb
+++ b/lib/protobuf/field/bool_field.rb
@@ -30,7 +30,7 @@ module Protobuf
         return true if val == TRUE_STRING
         return false if val == FALSE_STRING
 
-        val
+        fail TypeError, "Expected value of type '#{type_class}' for field #{name}, but got '#{val.class}'"
       end
 
       def decode(value)

--- a/lib/protobuf/field/float_field.rb
+++ b/lib/protobuf/field/float_field.rb
@@ -22,7 +22,7 @@ module Protobuf
 
       def coerce!(val)
         Float(val)
-      rescue
+      rescue ArgumentError
         fail TypeError, "Expected value of type '#{type_class}' for field #{name}, but got '#{val.class}'"
       end
 

--- a/lib/protobuf/field/float_field.rb
+++ b/lib/protobuf/field/float_field.rb
@@ -22,6 +22,8 @@ module Protobuf
 
       def coerce!(val)
         Float(val)
+      rescue
+        fail TypeError, "Expected value of type '#{type_class}' for field #{name}, but got '#{val.class}'"
       end
 
       def decode(bytes)

--- a/lib/protobuf/field/varint_field.rb
+++ b/lib/protobuf/field/varint_field.rb
@@ -54,8 +54,10 @@ module Protobuf
         int_val = if val.is_a?(Integer)
                     return true if val >= 0 && val < INT32_MAX # return quickly for smallest integer size, hot code path
                     val
+                  elsif val.is_a?(Numeric)
+                    val.to_i
                   else
-                    coerce!(val)
+                    Integer(val, 10)
                   end
 
         int_val >= self.class.min && int_val <= self.class.max
@@ -64,8 +66,11 @@ module Protobuf
       end
 
       def coerce!(val)
+        fail TypeError, "Expected value of type '#{type_class}' for field #{name}, but got '#{val.class}'" unless acceptable?(val)
         return val.to_i if val.is_a?(Numeric)
         Integer(val, 10)
+      rescue
+        fail TypeError, "Expected value of type '#{type_class}' for field #{name}, but got '#{val.class}'"
       end
 
       def decode(value)

--- a/lib/protobuf/field/varint_field.rb
+++ b/lib/protobuf/field/varint_field.rb
@@ -69,7 +69,7 @@ module Protobuf
         fail TypeError, "Expected value of type '#{type_class}' for field #{name}, but got '#{val.class}'" unless acceptable?(val)
         return val.to_i if val.is_a?(Numeric)
         Integer(val, 10)
-      rescue
+      rescue ArgumentError
         fail TypeError, "Expected value of type '#{type_class}' for field #{name}, but got '#{val.class}'"
       end
 

--- a/spec/lib/protobuf/field/float_field_spec.rb
+++ b/spec/lib/protobuf/field/float_field_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Protobuf::Field::FloatField do
       let(:value) { "aaaa" }
 
       it 'throws an error' do
-        expect { subject }.to raise_error(ArgumentError)
+        expect { subject }.to raise_error(TypeError)
       end
     end
 


### PR DESCRIPTION
…gic and use fetch instead of checking for key

most field types do acceptability check in `coerce!` and in `acceptable?`, this leaves acceptable but doesn't use it in the `set_field` method as the `coerce!` call will take care of that for us

also uses Hash `fetch` instead of doing a `key?` check before access as the default can be passed into the fetch and again avoid another conditional check

@film42