### PR TITLE
encode straight to stream without intermediary copies

### DIFF
--- a/lib/protobuf/encoder.rb
+++ b/lib/protobuf/encoder.rb
@@ -8,11 +8,11 @@ module Protobuf
             stream << "#{field.tag_encoded}#{::Protobuf::Field::VarintField.encode(packed_value.size)}#{packed_value}"
           else
             value.each do |val|
-              stream << "#{field.tag_encoded}#{field.encode(val)}"
+              field.encode_to_stream(val, stream)
             end
           end
         else
-          stream << "#{field.tag_encoded}#{field.encode(value)}"
+          field.encode_to_stream(value, stream)
         end
       end
 

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -90,6 +90,10 @@ module Protobuf
         fail NotImplementedError, "#{self.class.name}##{__method__}"
       end
 
+      def encode_to_stream(value, stream)
+        stream << tag_encoded << encode(value)
+      end
+
       def extension?
         options.key?(:extension)
       end

--- a/lib/protobuf/field/bytes_field.rb
+++ b/lib/protobuf/field/bytes_field.rb
@@ -46,6 +46,13 @@ module Protobuf
         "#{string_size}#{value_to_encode}"
       end
 
+      def encode_to_stream(value, stream)
+        value = value.encode if value.is_a?(::Protobuf::Message)
+        byte_size = ::Protobuf::Field::VarintField.encode(value.bytesize)
+
+        stream << tag_encoded << byte_size << value
+      end
+
       def wire_type
         ::Protobuf::WireType::LENGTH_DELIMITED
       end

--- a/lib/protobuf/field/string_field.rb
+++ b/lib/protobuf/field/string_field.rb
@@ -28,6 +28,16 @@ module Protobuf
         "#{::Protobuf::Field::VarintField.encode(value_to_encode.size)}#{value_to_encode}"
       end
 
+      def encode_to_stream(value, stream)
+        if value.encoding != ::Protobuf::Field::StringField::ENCODING
+          value = value.dup
+          value.encode!(::Protobuf::Field::StringField::ENCODING, :invalid => :replace, :undef => :replace, :replace => "")
+        end
+
+        byte_size = ::Protobuf::Field::VarintField.encode(value.bytesize)
+        stream << tag_encoded << byte_size << value
+      end
+
     end
   end
 end


### PR DESCRIPTION
Start reducing the amount of copying we do during encoding to a stream (which is the path taken because `encode` calls `encode_to` with a `StringIO`)

on MRI this doesn't make a significant difference

**BEFORE**
```bash
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)> Benchmark.measure do
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   10_000.times do  
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*     proto.encode
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   end  
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)* end  
=> #<Benchmark::Tms:0x0000000116e2b0 @cstime=0.0, @cutime=0.0, @label="", @real=0.13301530084572732, @stime=0.0, @total=0.1299999999999999, @utime=0.1299999999999999>
```

**AFTER**
```bash
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)> Benchmark.measure do
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   10_000.times do  
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*     proto.encode
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   end  
[4] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)* end  
=> #<Benchmark::Tms:0x000000044deca8 @cstime=0.0, @cutime=0.0, @label="", @real=0.10333655099384487, @stime=0.0, @total=0.10000000000000009, @utime=0.10000000000000009>
```

But on JRuby the difference is more pronounced in the total and utime

**BEFORE**
```bash
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)> Benchmark.measure do
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   10_000.times do
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*     proto.encode
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   end  
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)* end  
=> #<Benchmark::Tms:0x5cc87de4 @cstime=0.0, @cutime=0.0, @label="", @real=0.11006945697590709, @stime=0.0, @total=0.20000000000000284, @utime=0.20000000000000284>
[10] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)> Benchmark.measure do
[10] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   10_000.times do
[10] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*     proto.encode
[10] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   end  
[10] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)* end  
=> #<Benchmark::Tms:0x72a61e61 @cstime=0.0, @cutime=0.0, @label="", @real=0.10494967713020742, @stime=0.0, @total=0.3100000000000023, @utime=0.3100000000000023>
[11] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)> Benchmark.measure do
[11] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   10_000.times do
[11] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*     proto.encode
[11] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   end  
[11] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)* end  
=> #<Benchmark::Tms:0x5cf1bbd3 @cstime=0.0, @cutime=0.0, @label="", @real=0.1023686439730227, @stime=0.0, @total=0.28000000000000114, @utime=0.28000000000000114>
```

**AFTER**
```bash
[7] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)> Benchmark.measure do
[7] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   10_000.times do
[7] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*     proto.encode
[7] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   end  
[7] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)* end  
=> #<Benchmark::Tms:0x66859ea9 @cstime=0.0, @cutime=0.0, @label="", @real=0.09669065894559026, @stime=0.0, @total=0.14000000000000057, @utime=0.14000000000000057>
[8] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)> Benchmark.measure do
[8] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   10_000.times do
[8] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*     proto.encode
[8] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   end  
[8] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)* end  
=> #<Benchmark::Tms:0x3a359f7c @cstime=0.0, @cutime=0.0, @label="",@real=0.09078302001580596, @stime=0.010000000000000009, @total=0.13000000000000456, @utime=0.12000000000000455>
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)> Benchmark.measure do
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   10_000.times do
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*     proto.encode
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)*   end  
[9] pry(#<RSpec::ExampleGroups::ProtobufFieldStringField::Encode>)* end  
=> #<Benchmark::Tms:0x17063c32 @cstime=0.0, @cutime=0.0, @label="", @real=0.09246275201439857, @stime=0.0, @total=0.13000000000000256, @utime=0.13000000000000256>
```

@film42 @mmmries 