### PR TITLE
move dynamic rule checks to the initialize method

### DIFF
--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -47,6 +47,13 @@ module Protobuf
           set_option(option_name, value)
         end
 
+        @extension = options.key?(:extension)
+        @deprecated = options.key?(:deprecated)
+        @required = rule == :required
+        @repeated = rule == :repeated
+        @optional = rule == :optional
+        @packed = @repeated && options.key?(:packed)
+
         validate_packed_field if packed?
         define_accessor(simple_name, fully_qualified_name) if simple_name
         tag_encoded
@@ -83,7 +90,7 @@ module Protobuf
       end
 
       def deprecated?
-        options.key?(:deprecated)
+        @deprecated
       end
 
       def encode(_value)
@@ -95,7 +102,7 @@ module Protobuf
       end
 
       def extension?
-        options.key?(:extension)
+        @extension
       end
 
       def enum?
@@ -107,15 +114,15 @@ module Protobuf
       end
 
       def optional?
-        rule == :optional
+        @optional
       end
 
       def packed?
-        repeated? && options.key?(:packed)
+        @packed
       end
 
       def repeated?
-        rule == :repeated
+        @repeated
       end
 
       def repeated_message?
@@ -123,7 +130,7 @@ module Protobuf
       end
 
       def required?
-        rule == :required
+        @required
       end
 
       # FIXME: need to cleanup (rename) this warthog of a method.


### PR DESCRIPTION
tested in MRI and JRuby and instance variable checks are approx 10% faster than the rule comparison on each `repeated?` `required?` calls, since this is called a lot (during serialization) figured this would be better to use the faster path

@film42 