### PR TITLE
Use alias_method in place of alias_method_chain

### DIFF
--- a/lib/protobuf/code_generator.rb
+++ b/lib/protobuf/code_generator.rb
@@ -86,7 +86,8 @@ module Protobuf
         end
       end
 
-      alias_method_chain :set, :options
+      alias_method :set_without_options, :set
+      alias_method :set, :set_with_options
     end
   end
 end


### PR DESCRIPTION
Today activesupport 5.1.0 was released which no longer supports alias_method_chain. It was deprecated prior to this version. cc @nerdrew @film42 @abrandoned 