### PR TITLE
Add server_host to the response object

### DIFF
--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -37,6 +37,13 @@ module Protobuf
     #
     # The name or address of the host to use during client RPC calls.
     attr_writer :client_host
+
+    # Server Host
+    #
+    # Default: first ipv4 address of the system
+    #
+    # The name or address of the host to use during client RPC calls.
+    attr_writer :server_host
   end
 
   def self.client_host
@@ -80,6 +87,10 @@ module Protobuf
 
   def self.ignore_unknown_fields=(value)
     @ignore_unknown_fields = !!value
+  end
+
+  def self.server_host
+    @server_host ||= Socket.gethostname
   end
 end
 

--- a/lib/protobuf/rpc/error.rb
+++ b/lib/protobuf/rpc/error.rb
@@ -18,7 +18,7 @@ module Protobuf
       end
 
       def to_response
-        ::Protobuf::Socketrpc::Response.new(:error => message, :error_reason => error_type)
+        ::Protobuf::Socketrpc::Response.new(:error => message, :error_reason => error_type, :server => ::Protobuf.server_host)
       end
     end
   end

--- a/lib/protobuf/rpc/middleware/response_encoder.rb
+++ b/lib/protobuf/rpc/middleware/response_encoder.rb
@@ -72,9 +72,9 @@ module Protobuf
         #
         def wrapped_response
           if response.is_a?(::Protobuf::Rpc::PbError)
-            ::Protobuf::Socketrpc::Response.new(:error => response.message, :error_reason => response.error_type)
+            ::Protobuf::Socketrpc::Response.new(:error => response.message, :error_reason => response.error_type, :server => ::Protobuf.server_host)
           else
-            ::Protobuf::Socketrpc::Response.new(:response_proto => response.encode)
+            ::Protobuf::Socketrpc::Response.new(:response_proto => response.encode, :server => ::Protobuf.server_host)
           end
         end
       end

--- a/lib/protobuf/rpc/rpc.pb.rb
+++ b/lib/protobuf/rpc/rpc.pb.rb
@@ -48,6 +48,7 @@ module Protobuf
       optional :string, :error, 2
       optional :bool, :callback, 3, :default => false
       optional ::Protobuf::Socketrpc::ErrorReason, :error_reason, 4
+      optional :string, :server, 5
     end
 
   end

--- a/proto/rpc.proto
+++ b/proto/rpc.proto
@@ -38,6 +38,7 @@ message Response
   optional string error = 2;                    // Error message, if any
   optional bool callback = 3 [default = false]; // Was callback invoked (not sure what this is for)
   optional ErrorReason error_reason = 4;        // Error Reason
+  optional string server = 5;                   // Server hostname or address
 }
 
 // Possible error reasons

--- a/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
@@ -10,9 +10,12 @@ RSpec.describe Protobuf::Rpc::Middleware::ResponseEncoder do
   end
   let(:encoded_response) { response_wrapper.encode }
   let(:response) { Test::Resource.new(:name => 'required') }
-  let(:response_wrapper) { ::Protobuf::Socketrpc::Response.new(:response_proto => response) }
+  let(:response_wrapper) { ::Protobuf::Socketrpc::Response.new(:response_proto => response, :server => server_host) }
+  let(:server_host) { 'beepboopbop' }
 
   subject { described_class.new(app) }
+
+  before { ::Protobuf.server_host = server_host }
 
   describe "#call" do
     it "encodes the response" do


### PR DESCRIPTION
This allows tracing a request to a server when the transport layer does not use
direct connections, i.e., protobuf-nats.

---

RFC @mmmries @abrandoned @film42