### PR TITLE
Override stats#server from the response

### DIFF
--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -37,13 +37,6 @@ module Protobuf
     #
     # The name or address of the host to use during client RPC calls.
     attr_writer :client_host
-
-    # Server Host
-    #
-    # Default: first ipv4 address of the system
-    #
-    # The name or address of the host to use during client RPC calls.
-    attr_writer :server_host
   end
 
   def self.client_host
@@ -87,10 +80,6 @@ module Protobuf
 
   def self.ignore_unknown_fields=(value)
     @ignore_unknown_fields = !!value
-  end
-
-  def self.server_host
-    defined?(@server_host) ? @server_host : @server_host = Socket.gethostname
   end
 end
 

--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -37,13 +37,6 @@ module Protobuf
     #
     # The name or address of the host to use during client RPC calls.
     attr_writer :client_host
-
-    # Server Host
-    #
-    # Default: first ipv4 address of the system
-    #
-    # The name or address of the host to use during client RPC calls.
-    attr_accessor :server_host
   end
 
   def self.client_host

--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -37,6 +37,13 @@ module Protobuf
     #
     # The name or address of the host to use during client RPC calls.
     attr_writer :client_host
+
+    # Server Host
+    #
+    # Default: first ipv4 address of the system
+    #
+    # The name or address of the host to use during client RPC calls.
+    attr_accessor :server_host
   end
 
   def self.client_host

--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -47,7 +47,7 @@ module Protobuf
   end
 
   def self.client_host
-    @client_host ||= Socket.gethostname
+    defined?(@client_host) ? @client_host : @client_host = Socket.gethostname
   end
 
   def self.connector_type_class
@@ -90,7 +90,7 @@ module Protobuf
   end
 
   def self.server_host
-    @server_host ||= Socket.gethostname
+    defined?(@server_host) ? @server_host : @server_host = Socket.gethostname
   end
 end
 

--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -40,7 +40,7 @@ module Protobuf
   end
 
   def self.client_host
-    defined?(@client_host) ? @client_host : @client_host = Socket.gethostname
+    @client_host ||= Socket.gethostname
   end
 
   def self.connector_type_class

--- a/lib/protobuf/rpc/connectors/base.rb
+++ b/lib/protobuf/rpc/connectors/base.rb
@@ -104,6 +104,7 @@ module Protobuf
           # Parse out the raw response
           @stats.response_size = @response_data.size unless @response_data.nil?
           response_wrapper = ::Protobuf::Socketrpc::Response.decode(@response_data)
+          @stats.server = response_wrapper.server if response_wrapper.field?(:server)
 
           # Determine success or failure based on parsed data
           if response_wrapper.field?(:error_reason)

--- a/lib/protobuf/rpc/error.rb
+++ b/lib/protobuf/rpc/error.rb
@@ -18,7 +18,7 @@ module Protobuf
       end
 
       def to_response
-        ::Protobuf::Socketrpc::Response.new(:error => message, :error_reason => error_type)
+        ::Protobuf::Socketrpc::Response.new(:error => message, :error_reason => error_type, :server => ::Protobuf.server_host)
       end
     end
   end

--- a/lib/protobuf/rpc/error.rb
+++ b/lib/protobuf/rpc/error.rb
@@ -18,7 +18,7 @@ module Protobuf
       end
 
       def to_response
-        ::Protobuf::Socketrpc::Response.new(:error => message, :error_reason => error_type, :server => ::Protobuf.server_host)
+        ::Protobuf::Socketrpc::Response.new(:error => message, :error_reason => error_type)
       end
     end
   end

--- a/lib/protobuf/rpc/middleware/response_encoder.rb
+++ b/lib/protobuf/rpc/middleware/response_encoder.rb
@@ -72,9 +72,9 @@ module Protobuf
         #
         def wrapped_response
           if response.is_a?(::Protobuf::Rpc::PbError)
-            ::Protobuf::Socketrpc::Response.new(:error => response.message, :error_reason => response.error_type, :server => ::Protobuf.server_host)
+            ::Protobuf::Socketrpc::Response.new(:error => response.message, :error_reason => response.error_type)
           else
-            ::Protobuf::Socketrpc::Response.new(:response_proto => response.encode, :server => ::Protobuf.server_host)
+            ::Protobuf::Socketrpc::Response.new(:response_proto => response.encode)
           end
         end
       end

--- a/lib/protobuf/rpc/middleware/response_encoder.rb
+++ b/lib/protobuf/rpc/middleware/response_encoder.rb
@@ -72,9 +72,9 @@ module Protobuf
         #
         def wrapped_response
           if response.is_a?(::Protobuf::Rpc::PbError)
-            ::Protobuf::Socketrpc::Response.new(:error => response.message, :error_reason => response.error_type)
+            ::Protobuf::Socketrpc::Response.new(:error => response.message, :error_reason => response.error_type, :server => ::Protobuf.server_host)
           else
-            ::Protobuf::Socketrpc::Response.new(:response_proto => response.encode)
+            ::Protobuf::Socketrpc::Response.new(:response_proto => response.encode, :server => ::Protobuf.server_host)
           end
         end
       end

--- a/lib/protobuf/rpc/stat.rb
+++ b/lib/protobuf/rpc/stat.rb
@@ -6,7 +6,8 @@ module Protobuf
   module Rpc
     class Stat
       attr_accessor :mode, :start_time, :end_time, :request_size, :dispatcher
-      attr_accessor :response_size, :client, :server, :service, :method_name
+      attr_accessor :response_size, :client, :service, :method_name
+      attr_reader   :server
 
       MODES = [:SERVER, :CLIENT].freeze
 
@@ -32,11 +33,12 @@ module Protobuf
       end
 
       def server=(peer)
-        @server = { :port => peer[0], :ip => peer[1] }
-      end
-
-      def server
-        @server ? "#{@server[:ip]}:#{@server[:port]}" : nil
+        case peer
+        when Array
+          @server = "#{peer[1]}:#{peer[0]}"
+        when String
+          @server = peer
+        end
       end
 
       def service

--- a/lib/protobuf/version.rb
+++ b/lib/protobuf/version.rb
@@ -1,3 +1,3 @@
 module Protobuf
-  VERSION = '3.7.2.pre1' # rubocop:disable Style/MutableConstant
+  VERSION = '3.7.2' # rubocop:disable Style/MutableConstant
 end

--- a/lib/protobuf/version.rb
+++ b/lib/protobuf/version.rb
@@ -1,3 +1,3 @@
 module Protobuf
-  VERSION = '3.7.2' # rubocop:disable Style/MutableConstant
+  VERSION = '3.7.1' # rubocop:disable Style/MutableConstant
 end

--- a/lib/protobuf/version.rb
+++ b/lib/protobuf/version.rb
@@ -1,3 +1,3 @@
 module Protobuf
-  VERSION = '3.7.1' # rubocop:disable Style/MutableConstant
+  VERSION = '3.7.2.pre1' # rubocop:disable Style/MutableConstant
 end

--- a/spec/lib/protobuf/rpc/connectors/base_spec.rb
+++ b/spec/lib/protobuf/rpc/connectors/base_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Protobuf::Rpc::Connectors::Base do
       subject.parse_response
       expect(subject.stats.server).to eq("127.3.4.5:55589")
     end
+    it "does not override stats#server when response.server is nil" do
+      allow(subject).to receive(:close_connection)
+      subject.instance_variable_set(:@response_data, ::Protobuf::Socketrpc::Response.new(:server => nil).encode)
+      subject.initialize_stats
+      subject.parse_response
+      expect(subject.stats.server).to eq("127.3.4.5:55589")
+    end
   end
 
   describe "#any_callbacks?" do

--- a/spec/lib/protobuf/rpc/connectors/base_spec.rb
+++ b/spec/lib/protobuf/rpc/connectors/base_spec.rb
@@ -20,6 +20,24 @@ RSpec.describe Protobuf::Rpc::Connectors::Base do
     specify { expect(subject.respond_to?(:verify_callbacks)).to be true }
   end
 
+  describe "#parse_response" do
+    let(:options) { { :response_type => Test::Resource, :port => 55589, :host => '127.3.4.5' } }
+    it "updates stats#server from the response" do
+      allow(subject).to receive(:close_connection)
+      subject.instance_variable_set(:@response_data, ::Protobuf::Socketrpc::Response.new(:server => "serverless").encode)
+      subject.initialize_stats
+      subject.parse_response
+      expect(subject.stats.server).to eq("serverless")
+    end
+    it "does not override stats#server when response.server is missing" do
+      allow(subject).to receive(:close_connection)
+      subject.instance_variable_set(:@response_data, ::Protobuf::Socketrpc::Response.new.encode)
+      subject.initialize_stats
+      subject.parse_response
+      expect(subject.stats.server).to eq("127.3.4.5:55589")
+    end
+  end
+
   describe "#any_callbacks?" do
     [:@complete_cb, :@success_cb, :@failure_cb].each do |cb|
       it "returns true if #{cb} is provided" do

--- a/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
@@ -10,12 +10,9 @@ RSpec.describe Protobuf::Rpc::Middleware::ResponseEncoder do
   end
   let(:encoded_response) { response_wrapper.encode }
   let(:response) { Test::Resource.new(:name => 'required') }
-  let(:response_wrapper) { ::Protobuf::Socketrpc::Response.new(:response_proto => response, :server => server_host) }
-  let(:server_host) { 'beepboopbop' }
+  let(:response_wrapper) { ::Protobuf::Socketrpc::Response.new(:response_proto => response) }
 
   subject { described_class.new(app) }
-
-  before { ::Protobuf.server_host = server_host }
 
   describe "#call" do
     it "encodes the response" do

--- a/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
@@ -10,9 +10,12 @@ RSpec.describe Protobuf::Rpc::Middleware::ResponseEncoder do
   end
   let(:encoded_response) { response_wrapper.encode }
   let(:response) { Test::Resource.new(:name => 'required') }
-  let(:response_wrapper) { ::Protobuf::Socketrpc::Response.new(:response_proto => response) }
+  let(:response_wrapper) { ::Protobuf::Socketrpc::Response.new(:response_proto => response, :server => server_host) }
+  let(:server_host) { 'beepboopbop' }
 
   subject { described_class.new(app) }
+
+  before { ::Protobuf.server_host = server_host }
 
   describe "#call" do
     it "encodes the response" do

--- a/spec/lib/protobuf/rpc/stat_spec.rb
+++ b/spec/lib/protobuf/rpc/stat_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe ::Protobuf::Rpc::Stat do
     BarService = ::Struct.new(:method_name) unless defined?(BarService)
   end
 
+  describe '#server=' do
+    it 'understands Array' do
+      stat = ::Protobuf::Rpc::Stat.new
+      stat.server = [3333, "127.0.0.1"]
+      expect(stat.server).to eq("127.0.0.1:3333")
+    end
+
+    it 'understands String' do
+      stat = ::Protobuf::Rpc::Stat.new
+      stat.server = "thatserverthough"
+      expect(stat.server).to eq("thatserverthough")
+    end
+  end
+
   describe 'server mode' do
     it 'describes a server response to a client' do
       ::Timecop.freeze(10.minutes.ago) do


### PR DESCRIPTION
This ensures that the server fulfilling a request will correctly end up in the logs.

@abrandoned @film42 