### PR TITLE
Allow a server to be set in the response

### DIFF
--- a/lib/protobuf/rpc/env.rb
+++ b/lib/protobuf/rpc/env.rb
@@ -45,6 +45,7 @@ module Protobuf
                     :response_type,
                     :rpc_method,
                     :rpc_service,
+                    :server,
                     :service_name,
                     :worker_id
 

--- a/lib/protobuf/rpc/middleware/response_encoder.rb
+++ b/lib/protobuf/rpc/middleware/response_encoder.rb
@@ -72,9 +72,9 @@ module Protobuf
         #
         def wrapped_response
           if response.is_a?(::Protobuf::Rpc::PbError)
-            ::Protobuf::Socketrpc::Response.new(:error => response.message, :error_reason => response.error_type)
+            ::Protobuf::Socketrpc::Response.new(:error => response.message, :error_reason => response.error_type, :server => env.server)
           else
-            ::Protobuf::Socketrpc::Response.new(:response_proto => response.encode)
+            ::Protobuf::Socketrpc::Response.new(:response_proto => response.encode, :server => env.server)
           end
         end
       end

--- a/lib/protobuf/rpc/server.rb
+++ b/lib/protobuf/rpc/server.rb
@@ -20,10 +20,10 @@ module Protobuf
 
       # Invoke the service method dictated by the proto wrapper request object
       #
-      def handle_request(request_data)
+      def handle_request(request_data, env_data = {})
         # Create an env object that holds different parts of the environment and
         # is available to all of the middlewares
-        env = Env.new('encoded_request' => request_data, 'log_signature' => log_signature)
+        env = Env.new(env_data.merge('encoded_request' => request_data, 'log_signature' => log_signature))
 
         # Invoke the middleware stack, the last of which is the service dispatcher
         env = Rpc.middleware.call(env)

--- a/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/response_encoder_spec.rb
@@ -71,5 +71,21 @@ RSpec.describe Protobuf::Rpc::Middleware::ResponseEncoder do
         expect { subject.call(env) }.to raise_exception(Protobuf::Rpc::PbError)
       end
     end
+
+    context "when server exists in the env" do
+      let(:env) do
+        Protobuf::Rpc::Env.new(
+          'response_type' => Test::Resource,
+          'log_signature' => 'log_signature',
+          'server'        => 'itsaserver',
+        )
+      end
+
+      it "adds the servers to the response" do
+        expected_response = ::Protobuf::Socketrpc::Response.new(:response_proto => response, :server => 'itsaserver').encode
+        subject.call(env)
+        expect(env.encoded_response).to eq(expected_response)
+      end
+    end
   end
 end


### PR DESCRIPTION
This will allow an rpc server implementation to override the server that is
reported in logs.

---

RFC @film42