### PR TITLE
prevent infinite loop on socket create when a problem

### DIFF
--- a/lib/protobuf/rpc/connectors/zmq.rb
+++ b/lib/protobuf/rpc/connectors/zmq.rb
@@ -104,6 +104,7 @@ module Protobuf
             end
 
             if !has_reloaded_context && attempt_number == socket_creation_attempts
+              logger.info { sign_message("Reset Context: could not create socket") }
               zmq_context(true) # reload the context
               attempt_number = 0
               has_reloaded_context = true

--- a/lib/protobuf/rpc/connectors/zmq.rb
+++ b/lib/protobuf/rpc/connectors/zmq.rb
@@ -28,7 +28,8 @@ module Protobuf
           @ping_port_responses ||= ::ThreadSafe::Cache.new
         end
 
-        def self.zmq_context
+        def self.zmq_context(reload = false)
+          @zmq_contexts = nil if reload
           @zmq_contexts ||= Hash.new do |hash, key|
             hash[key] = ZMQ::Context.new
           end
@@ -88,6 +89,7 @@ module Protobuf
         # service. The LINGER is set to 0 so we can close immediately in
         # the event of a timeout
         def create_socket
+          has_reloaded_context = false
           attempt_number = 0
 
           begin
@@ -99,6 +101,12 @@ module Protobuf
               socket.setsockopt(::ZMQ::LINGER, 0)
               zmq_error_check(socket.connect(server_uri), :socket_connect)
               socket = socket_to_available_server(socket) if first_alive_load_balance?
+            end
+
+            if !has_reloaded_context && attempt_number == socket_creation_attempts
+              zmq_context(true) # reload the context
+              attempt_number = 0
+              has_reloaded_context = true
             end
           end while socket.nil? && attempt_number < socket_creation_attempts
 
@@ -271,8 +279,8 @@ module Protobuf
         # If the context does not exist, create it, then register
         # an exit block to ensure the context is terminated correctly.
         #
-        def zmq_context
-          self.class.zmq_context
+        def zmq_context(reload = false)
+          self.class.zmq_context(reload)
         end
 
         def zmq_eagain_error_check(return_code, source)


### PR DESCRIPTION
We found an issue when a network problem happens and a context cannot get a socket issued it will loop here forever and essentially kill the server it runs on (taking all CPU)

put in 2 attempts at "fixing" ... will retry the socket creation (configured number of times || 5 times) and then will reload the zmq_context and will retry the socket creation again (same number of times)

This should mitigate a bad context and a scenario when all is lost and it needs to just stop busy loop

@film42 @quixoten 