### PR TITLE
fix socket check in zmq connector to check the internal socket

### DIFF
--- a/lib/protobuf/rpc/connectors/zmq.rb
+++ b/lib/protobuf/rpc/connectors/zmq.rb
@@ -109,9 +109,9 @@ module Protobuf
               attempt_number = 0
               has_reloaded_context = true
             end
-          end while socket.nil? && attempt_number < socket_creation_attempts
+          end while socket.try(:socket).nil? && attempt_number < socket_creation_attempts
 
-          raise RequestTimeout, "Cannot create new ZMQ client socket" if socket.nil?
+          raise RequestTimeout, "Cannot create new ZMQ client socket" if socket.try(:socket).nil?
           socket
         end
 


### PR DESCRIPTION
have seen increased errors `RuntimeError: Last ZMQ API call to socket_send_string failed with "Socket operation on non-socket".`

apparently this can happen if the underlying socket is closed but the zeromq socket is still present; should revert back to checking the internal socket for `nil?` in zeromq connector instead of the returned socket

https://github.com/zeromq/jzmq/issues/443

@brianstien @film42 @quixoten 