### PR TITLE
Allow to use rake task inside custom task many times

### DIFF
--- a/lib/protobuf/tasks/compile.rake
+++ b/lib/protobuf/tasks/compile.rake
@@ -22,7 +22,7 @@ namespace :protobuf do
     full_command = command.join(' ')
 
     puts full_command
-    exec(full_command)
+    system(full_command)
   end
 
   desc 'Clean the generated *.pb.rb files from the destination package. Pass PB_FORCE_CLEAN=1 to skip confirmation step.'


### PR DESCRIPTION
This fix allows to reuse `::Rake::Task['protobuf:compile'].invoke` in custom rake tasks.
Because `system` call doesn't replace current process, but `exec` does.