### PR TITLE
Add option to have require_relative statements

### DIFF
--- a/lib/protobuf/generators/file_generator.rb
+++ b/lib/protobuf/generators/file_generator.rb
@@ -125,7 +125,7 @@ module Protobuf
         header "Imports"
 
         descriptor.dependency.each do |dependency|
-          print_require(convert_filename(dependency))
+          print_require(convert_filename(dependency), ENV.key?('PB_REQUIRE_RELATIVE'))
         end
 
         puts

--- a/lib/protobuf/generators/printable.rb
+++ b/lib/protobuf/generators/printable.rb
@@ -127,8 +127,8 @@ module Protobuf
       #
       #   print_require('foo/bar/baz') -> "require 'foo/bar/baz'"
       #
-      def print_require(file)
-        puts "require '#{file}'"
+      def print_require(file, relative = false)
+        puts "require#{'_relative' if relative} '#{file}'"
       end
 
       # Puts the given message prefixed by the indent level.

--- a/spec/lib/protobuf/generators/file_generator_spec.rb
+++ b/spec/lib/protobuf/generators/file_generator_spec.rb
@@ -22,11 +22,18 @@ RSpec.describe ::Protobuf::Generators::FileGenerator do
     end
 
     it 'prints a ruby require for each dependency' do
-      expect(subject).to receive(:print_require).with('test/bar.pb')
-      expect(subject).to receive(:print_require).with('test/baz.pb')
+      expect(subject).to receive(:print_require).with('test/bar.pb', false)
+      expect(subject).to receive(:print_require).with('test/baz.pb', false)
       subject.print_import_requires
     end
 
+    it 'prints a ruby require_relative for each dependency if environment variable was set' do
+      expect(subject).to receive(:print_require).with('test/bar.pb', true)
+      expect(subject).to receive(:print_require).with('test/baz.pb', true)
+      ENV['PB_REQUIRE_RELATIVE'] = 'true'
+      subject.print_import_requires
+      ENV.delete('PB_REQUIRE_RELATIVE')
+    end
   end
 
   describe '#compile' do


### PR DESCRIPTION
To account for this issue: https://github.com/ruby-protobuf/protobuf/issues/240. 

I chose to use an environment variable `REQUIRE_RELATIVE=true` as I can't see another way to pass options to the gem