### PR TITLE
Update the compile task to work with protoc v3

### DIFF
--- a/lib/protobuf/tasks/compile.rake
+++ b/lib/protobuf/tasks/compile.rake
@@ -1,13 +1,32 @@
-require 'fileutils'
+require "fileutils"
 
 namespace :protobuf do
 
-  desc 'Clean & Compile the protobuf source to ruby classes. Pass PB_NO_CLEAN=1 if you do not want to force-clean first.'
+  desc "Clean & Compile the protobuf source to ruby classes. Pass PB_NO_CLEAN=1 if you do not want to force-clean first."
   task :compile, [:package, :source, :destination, :plugin, :file_extension] do |_tasks, args|
-    args.with_defaults(:destination => 'lib')
-    args.with_defaults(:source => 'definitions')
-    args.with_defaults(:plugin => 'ruby')
-    args.with_defaults(:file_extension => '.pb.rb')
+    binpath = ::File.expand_path("../../../../bin", __FILE__)
+
+    args.with_defaults(:destination => "lib")
+    args.with_defaults(:source => "definitions")
+    args.with_defaults(:plugin => "protoc-gen-ruby-protobuf=#{binpath}/protoc-gen-ruby")
+    args.with_defaults(:file_extension => ".pb.rb")
+
+    # The local Ruby generator collides with the builtin Ruby generator
+    #
+    # From the protoc docs:
+    #
+    #   --plugin=EXECUTABLE
+    #
+    #   ...EXECUTABLE may be of the form NAME=PATH, in which case the given plugin name
+    #   is mapped to the given executable even if the executable"s own name differs.
+    #
+    # Use the NAME=PATH form to specify an alternative plugin name that avoids the name collision
+    #
+    plugin_name, _plugin_path = args[:plugin].split("=")
+
+    # The plugin name MUST have the protoc-gen- prefix in order to work, but that prefix is dropped
+    # when using the plugin to generate definitions
+    plugin_name.gsub!("protoc-gen-", "")
 
     unless do_not_clean?
       force_clean!
@@ -16,22 +35,23 @@ namespace :protobuf do
 
     command = []
     command << "protoc"
-    command << "--#{args[:plugin]}_out=#{args[:destination]}"
+    command << "--plugin=#{args[:plugin]}"
+    command << "--#{plugin_name}_out=#{args[:destination]}"
     command << "-I #{args[:source]}"
     command << Dir["#{args[:source]}/#{args[:package]}/**/*.proto"].join(" ")
-    full_command = command.join(' ')
+    full_command = command.join(" ")
 
     puts full_command
     system(full_command)
   end
 
-  desc 'Clean the generated *.pb.rb files from the destination package. Pass PB_FORCE_CLEAN=1 to skip confirmation step.'
+  desc "Clean the generated *.pb.rb files from the destination package. Pass PB_FORCE_CLEAN=1 to skip confirmation step."
   task :clean, [:package, :destination, :file_extension] do |_task, args|
-    args.with_defaults(:destination => 'lib')
-    args.with_defaults(:file_extension => '.pb.rb')
+    args.with_defaults(:destination => "lib")
+    args.with_defaults(:file_extension => ".pb.rb")
 
-    file_extension = args[:file_extension].sub(/\*?\.+/, '')
-    files_to_clean = ::File.join(args[:destination], args[:package], '**', "*.#{file_extension}")
+    file_extension = args[:file_extension].sub(/\*?\.+/, "")
+    files_to_clean = ::File.join(args[:destination], args[:package], "**", "*.#{file_extension}")
 
     if force_clean? || permission_to_clean?(files_to_clean)
       ::Dir.glob(files_to_clean).each do |file|
@@ -41,15 +61,15 @@ namespace :protobuf do
   end
 
   def do_not_clean?
-    ! ::ENV.key?('PB_NO_CLEAN')
+    ! ::ENV.key?("PB_NO_CLEAN")
   end
 
   def force_clean?
-    ::ENV.key?('PB_FORCE_CLEAN')
+    ::ENV.key?("PB_FORCE_CLEAN")
   end
 
   def force_clean!
-    ::ENV['PB_FORCE_CLEAN'] = '1'
+    ::ENV["PB_FORCE_CLEAN"] = "1"
   end
 
   def permission_to_clean?(files_to_clean)


### PR DESCRIPTION
The Protocol Buffers v3 compiler (protoc) now comes with a builtin Ruby plugin. This conflicts with our local custom Ruby plugin. In order to use it, the custom plugin must be passed to the compiler, and invoked via the custom output generator:

```
$ protoc --plugin=protoc-gen-ruby-protobuf=/path/to/bin/protoc-gen-ruby --ruby-protobuf_out=lib
```

Update the compile task to take this new pattern into account so that it works with both the v2 and v3 compilers.

// @film42 @brianstien