### PR TITLE
Implement Enum#to_json to

### DIFF
--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -288,7 +288,7 @@ module Protobuf
     #     render Protobuf enums correctly because to_json is not defined.
     #
     def to_json
-      to_s
+      to_i
     end
 
     def to_s(format = :tag)

--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -283,6 +283,14 @@ module Protobuf
       tag.to_int
     end
 
+    ##
+    # This fixes a reflection bug in JrJackson RubyAnySerializer that does not
+    #     render Protobuf enums correctly because to_json is not defined.
+    #
+    def to_json
+      to_s
+    end
+
     def to_s(format = :tag)
       case format
       when :tag

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Protobuf::Enum do
 
     describe '.to_json' do
       it 'renders the enum value' do
-        expect(Test::EnumTestType::ONE.to_json).to eq("1")
+        expect(Test::EnumTestType::ONE.to_json).to eq(1)
         expect({ :value => Test::EnumTestType::ONE }.to_json).to eq(%({"value":1}))
       end
     end

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -160,6 +160,13 @@ RSpec.describe Protobuf::Enum do
       end
     end
 
+    describe '.to_json' do
+      it 'renders the enum value' do
+        expect(Test::EnumTestType::ONE.to_json).to eq("1")
+        expect({ :value => Test::EnumTestType::ONE }.to_json).to eq(%({"value":1}))
+      end
+    end
+
     describe '.valid_tag?' do
       context 'when tag is defined' do
         specify { expect(Test::EnumTestType.valid_tag?(tag)).to be true }


### PR DESCRIPTION
There is an issue in JrJackson RubyAnySerializer that does not render Protobuf::Enum correctly because it does not implement to_json. This fixes that issue here until the serializer can be patched.

@abrandoned @ah @brianstien 