### PR TITLE
Fix enum's to_json

### DIFF
--- a/lib/protobuf/enum.rb
+++ b/lib/protobuf/enum.rb
@@ -283,12 +283,13 @@ module Protobuf
       tag.to_int
     end
 
-    ##
     # This fixes a reflection bug in JrJackson RubyAnySerializer that does not
-    #     render Protobuf enums correctly because to_json is not defined.
+    # render Protobuf enums correctly because to_json is not defined. It takes
+    # any number of arguments to support the JSON gem trying to pass an argument.
+    # NB: This method is required to return a string and not an integer.
     #
-    def to_json
-      to_i
+    def to_json(*)
+      to_s
     end
 
     def to_s(format = :tag)

--- a/spec/lib/protobuf/enum_spec.rb
+++ b/spec/lib/protobuf/enum_spec.rb
@@ -162,8 +162,10 @@ RSpec.describe Protobuf::Enum do
 
     describe '.to_json' do
       it 'renders the enum value' do
-        expect(Test::EnumTestType::ONE.to_json).to eq(1)
+        expect(Test::EnumTestType::ONE.to_json).to eq("1")
         expect({ :value => Test::EnumTestType::ONE }.to_json).to eq(%({"value":1}))
+        # JSON.dump passes arguments to the to_json method which broke in the 3.8.3 release.
+        expect(JSON.dump(:value => Test::EnumTestType::ONE)).to eq(%({"value":1}))
       end
     end
 


### PR DESCRIPTION
This PR fixes two regressions from #385.

First, `to_json` needs to return a string:
```ruby
irb(main):003:0> 5.to_json
=> "5"
```

Second, when using `JSON.dump`, `to_json` is expected to take a `JSON::State` argument - see ActiveSupport's comment [here](https://github.com/rails/rails/blob/b5aa0266d0a4d5f7a02eb31df730fa172d1a845a/activesupport/lib/active_support/core_ext/object/json.rb#L34-L46).