### PR TITLE
Creating request fields in new Base#request_fields method.

### DIFF
--- a/lib/protobuf/rpc/connectors/base.rb
+++ b/lib/protobuf/rpc/connectors/base.rb
@@ -137,14 +137,16 @@ module Protobuf
           ENV.key?("PB_RPC_PING_PORT")
         end
 
+        def request_fields
+          { :service_name => @options[:service].name,
+            :method_name => @options[:method].to_s,
+            :request_proto => @options[:request],
+            :caller => request_caller }
+        end
+
         def request_bytes
           validate_request_type!
-          fields = { :service_name => @options[:service].name,
-                     :method_name => @options[:method].to_s,
-                     :request_proto => @options[:request],
-                     :caller => request_caller }
-
-          return ::Protobuf::Socketrpc::Request.encode(fields)
+          return ::Protobuf::Socketrpc::Request.encode(request_fields)
         rescue => e
           failure(:INVALID_REQUEST_PROTO, "Could not set request proto: #{e.message}")
         end

--- a/lib/protobuf/rpc/connectors/base.rb
+++ b/lib/protobuf/rpc/connectors/base.rb
@@ -137,13 +137,6 @@ module Protobuf
           ENV.key?("PB_RPC_PING_PORT")
         end
 
-        def request_fields
-          { :service_name => @options[:service].name,
-            :method_name => @options[:method].to_s,
-            :request_proto => @options[:request],
-            :caller => request_caller }
-        end
-
         def request_bytes
           validate_request_type!
           return ::Protobuf::Socketrpc::Request.encode(request_fields)
@@ -153,6 +146,13 @@ module Protobuf
 
         def request_caller
           @options[:client_host] || ::Protobuf.client_host
+        end
+
+        def request_fields
+          { :service_name => @options[:service].name,
+            :method_name => @options[:method].to_s,
+            :request_proto => @options[:request],
+            :caller => request_caller }
         end
 
         def send_request


### PR DESCRIPTION
This, in addition to https://github.com/ruby-protobuf/protobuf/pull/393, will let us inject tracing information on the client in a clean way so that it can be sent on requests.