### PR TITLE
Server before/afer startup callbacks

### DIFF
--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -54,6 +54,18 @@ module Protobuf
     attr_writer :client_host
   end
 
+  def self.after_server_bind(&block)
+    ::ActiveSupport::Notifications.subscribe('after_server_bind') do |*args|
+      block.call(*args)
+    end
+  end
+
+  def self.before_server_bind(&block)
+    ::ActiveSupport::Notifications.subscribe('before_server_bind') do |*args|
+      block.call(*args)
+    end
+  end
+
   def self.client_host
     @client_host ||= Socket.gethostname
   end

--- a/lib/protobuf/cli.rb
+++ b/lib/protobuf/cli.rb
@@ -240,6 +240,8 @@ module Protobuf
       def start_server
         debug_say('Running server')
 
+        ::ActiveSupport::Notifications.instrument("before_server_bind")
+
         runner.run do
           logger.info do
             "pid #{::Process.pid} -- #{mode} RPC Server listening at #{options.host}:#{options.port}"

--- a/spec/lib/protobuf/cli_spec.rb
+++ b/spec/lib/protobuf/cli_spec.rb
@@ -275,6 +275,17 @@ RSpec.describe ::Protobuf::CLI do
         end
       end
 
+      context 'before server bind' do
+        it 'publishes a message before the runner runs' do
+          server_published_message_before_bind = false
+          ::ActiveSupport::Notifications.subscribe('before_server_bind') do
+            server_published_message_before_bind = true
+          end
+          described_class.start(args)
+          expect(server_published_message_before_bind).to eq(true)
+        end
+      end
+
     end
 
   end

--- a/spec/lib/protobuf/cli_spec.rb
+++ b/spec/lib/protobuf/cli_spec.rb
@@ -275,14 +275,38 @@ RSpec.describe ::Protobuf::CLI do
         end
       end
 
-      context 'before server bind' do
-        it 'publishes a message before the runner runs' do
-          server_published_message_before_bind = false
-          ::ActiveSupport::Notifications.subscribe('before_server_bind') do
-            server_published_message_before_bind = true
+      context 'after server bind' do
+        let(:sock_runner) { double("FakeRunner", :run => nil) }
+
+        before { allow(sock_runner).to receive(:run).and_yield }
+
+        it 'publishes when using the lib/protobuf callback' do
+          message_after_bind = false
+          ::Protobuf.after_server_bind do
+            message_after_bind = true
           end
           described_class.start(args)
-          expect(server_published_message_before_bind).to eq(true)
+          expect(message_after_bind).to eq(true)
+        end
+      end
+
+      context 'before server bind' do
+        it 'publishes a message before the runner runs' do
+          message_before_bind = false
+          ::ActiveSupport::Notifications.subscribe('before_server_bind') do
+            message_before_bind = true
+          end
+          described_class.start(args)
+          expect(message_before_bind).to eq(true)
+        end
+
+        it 'publishes when using the lib/protobuf callback' do
+          message_before_bind = false
+          ::Protobuf.before_server_bind do
+            message_before_bind = true
+          end
+          described_class.start(args)
+          expect(message_before_bind).to eq(true)
         end
       end
 


### PR DESCRIPTION
We currently have the ability to subscribe to callbacks via:

```
ActiveSupport::Notifications.subscribe('after_server_bind') { ... }
``` 

This proposes 2 changes:

1. Add a new `before_server_bind` event that is published before a runner's `run` method is called via the CLI.
2. A new helper method for {before,after}_server_bind on the Protobuf module.

Example:

```ruby
Protobuf.before_server_bind do
  eager_load_some_data_only_when_server_starts!
end

Protobuf.after_server_bind do
  report_server_online!
end
```

I also considered adding these to the `Protobuf::Rpc::Server` module since it's more specific to the use-case, but felt like the root `Protobuf`  was "good enough" so please let me know if you have a strong preference either way.

cc @liveh2o @abrandoned 