### PR TITLE
Update TravisCI build

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   Exclude:
     - 'spec/support/protos/*.pb.rb'
     - 'varint_prof.rb'
+    - 'protobuf-*/**/*.rb'
 
 Lint/EndAlignment:
   AlignWith: keyword

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ rvm:
   - rbx-2
 env:
   - PROTOBUF_VERSION=2.6.1
-  - PROTOBUF_VERSION=3.0.0-alpha-2
+  - PROTOBUF_VERSION=3.0.0
 matrix:
   allow_failures:
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ env:
 matrix:
   allow_failures:
     - rvm: rbx-2
-    - env: PROTOBUF_VERSION=3.0.0-alpha-2
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ rvm:
 env:
   - PROTOBUF_VERSION=2.6.1
   - PROTOBUF_VERSION=3.0.0
+  - PROTOBUF_VERSION=3.6.0
+  - PROTOBUF_VERSION=3.11.0
 matrix:
   allow_failures:
     - rvm: rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,26 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :development do
+  # debuggers only work in MRI
+  if RUBY_ENGINE.to_sym == :ruby
+    if RUBY_VERSION < '2.0.0'
+      gem 'pry-debugger'
+    elsif RUBY_VERSION < '2.4.0'
+      gem 'pry-byebug'
+      gem 'pry', '~> 0.12.0'
+    else
+      gem 'pry-byebug', '~> 3.9.0'
+      gem 'pry', '~> 0.13.0'
+    end
+
+    gem 'pry-stack_explorer'
+
+    gem 'varint'
+    gem 'ruby-prof'
+  elsif RUBY_PLATFORM =~ /java/i
+    gem 'fast_blank_java'
+    gem 'pry'
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ namespace :compile do
   task :spec do
     proto_path = ::File.expand_path('../spec/support/', __FILE__)
     proto_files = Dir[File.join(proto_path, '**', '*.proto')]
-    cmd = %(protoc --plugin=./bin/protoc-gen-ruby --ruby_out=#{proto_path} -I #{proto_path} #{proto_files.join(' ')})
+    cmd = %(protoc --plugin=protoc-gen-ruby-protobuf=./bin/protoc-gen-ruby --ruby-protobuf_out=#{proto_path} -I #{proto_path} #{proto_files.join(' ')})
 
     puts cmd
     system(cmd)
@@ -35,7 +35,7 @@ namespace :compile do
     output_dir = ::File.expand_path('../tmp/rpc', __FILE__)
     ::FileUtils.mkdir_p(output_dir)
 
-    cmd = %(protoc --plugin=./bin/protoc-gen-ruby --ruby_out=#{output_dir} -I #{proto_path} #{proto_files.join(' ')})
+    cmd = %(protoc --plugin=protoc-gen-ruby-protobuf=./bin/protoc-gen-ruby --ruby-protobuf_out=#{output_dir} -I #{proto_path} #{proto_files.join(' ')})
 
     puts cmd
     system(cmd)

--- a/protobuf.gemspec
+++ b/protobuf.gemspec
@@ -35,23 +35,4 @@ require "protobuf/version"
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'yard'
-
-  # debuggers only work in MRI
-  if RUBY_ENGINE.to_sym == :ruby
-    # we don't support MRI < 1.9.3
-    pry_debugger = if RUBY_VERSION < '2.0.0'
-                     'pry-debugger'
-                   else
-                     'pry-byebug'
-                   end
-
-    s.add_development_dependency pry_debugger
-    s.add_development_dependency 'pry-stack_explorer'
-
-    s.add_development_dependency 'varint'
-    s.add_development_dependency 'ruby-prof'
-  elsif RUBY_PLATFORM =~ /java/i
-    s.add_development_dependency 'fast_blank_java'
-    s.add_development_dependency 'pry'
-  end
 end


### PR DESCRIPTION
Builds on newer protobuf versions while not allowing failures.

Follow-up for #406, which made the build for protobuf 3.0.0 green.