### PR TITLE
#to_json(:lower_camel_case) generates camel cased keys

### DIFF
--- a/lib/protobuf/field/field_array.rb
+++ b/lib/protobuf/field/field_array.rb
@@ -49,14 +49,14 @@ module Protobuf
       # Return a hash-representation of the given values for this field type
       # that is safe to convert to JSON.
       # The value in this case would be an array.
-      def to_json_hash_value
+      def to_json_hash_value(options = {})
         if field.respond_to?(:json_encode)
           map do |value|
             field.json_encode(value)
           end
         else
           map do |value|
-            value.respond_to?(:to_json_hash_value) ? value.to_json_hash_value : value
+            value.respond_to?(:to_json_hash_value) ? value.to_json_hash_value(options) : value
           end
         end
       end

--- a/lib/protobuf/field/field_hash.rb
+++ b/lib/protobuf/field/field_hash.rb
@@ -58,14 +58,14 @@ module Protobuf
       # The value in this case would be the hash itself, right? Unfortunately
       # not because the values of the map could be messages themselves that we
       # need to transform.
-      def to_json_hash_value
+      def to_json_hash_value(options = {})
         if field.respond_to?(:json_encode)
           each_with_object({}) do |(key, value), hash|
             hash[key] = field.json_encode(value)
           end
         else
           each_with_object({}) do |(key, value), hash|
-            hash[key] = value.respond_to?(:to_json_hash_value) ? value.to_json_hash_value : value
+            hash[key] = value.respond_to?(:to_json_hash_value) ? value.to_json_hash_value(options) : value
           end
         end
       end

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -151,7 +151,7 @@ module Protobuf
         # NB: to_json_hash_value should come before json_encode so as to handle
         # repeated fields without extra logic.
         hashed_value = if value.respond_to?(:to_json_hash_value)
-                         value.to_json_hash_value
+                         value.to_json_hash_value(options)
                        elsif field.respond_to?(:json_encode)
                          field.json_encode(value)
                        else

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -134,13 +134,15 @@ module Protobuf
     end
 
     def to_json(options = {})
-      to_json_hash.to_json(options)
+      to_json_hash(options).to_json(options)
     end
 
     # Return a hash-representation of the given fields for this message type that
     # is safe to convert to JSON.
-    def to_json_hash
+    def to_json_hash(options = {})
       result = {}
+
+      lower_camel_case = options[:lower_camel_case]
 
       @values.each_key do |field_name|
         value = self[field_name]
@@ -156,7 +158,8 @@ module Protobuf
                          value
                        end
 
-        result[field.name] = hashed_value
+        key = lower_camel_case ? field.name.to_s.camelize(:lower).to_sym : field.name
+        result[key] = hashed_value
       end
 
       result

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -437,6 +437,16 @@ RSpec.describe Protobuf::Message do
 
       specify { expect(subject.to_json).to eq '{"widget_bytes":["Bo0xSFAXOmI="]}' }
     end
+
+    context 'using lower camel case field names' do
+      let(:bytes) { "\x06\x8D1HP\x17:b" }
+
+      subject do
+        ::Test::ResourceFindRequest.new(:widget_bytes => [bytes])
+      end
+
+      specify { expect(subject.to_json(:lower_camel_case => true)).to eq '{"widgetBytes":["Bo0xSFAXOmI="]}' }
+    end
   end
 
   describe '.to_json' do


### PR DESCRIPTION
This is a fix for #408

I wasn't sure where to update the documentation - please let me know if you require more changes.