### PR TITLE
Add Message.from_json

### DIFF
--- a/lib/protobuf/field/bytes_field.rb
+++ b/lib/protobuf/field/bytes_field.rb
@@ -48,7 +48,15 @@ module Protobuf
 
       def coerce!(value)
         case value
-        when String, Symbol
+        when String
+          if value.encoding == Encoding::ASCII_8BIT
+            # This is a "binary" string
+            value
+          else
+            # Assume the value is Base64 encoded (from JSON)
+            Base64.decode64(value)
+          end
+        when Symbol
           value.to_s
         when NilClass
           nil

--- a/lib/protobuf/field/field_array.rb
+++ b/lib/protobuf/field/field_array.rb
@@ -81,6 +81,8 @@ module Protobuf
 
         if field.is_a?(::Protobuf::Field::EnumField)
           field.type_class.fetch(value)
+        elsif field.is_a?(::Protobuf::Field::BytesField)
+          field.coerce!(value)
         elsif field.is_a?(::Protobuf::Field::MessageField) && value.is_a?(field.type_class)
           value
         elsif field.is_a?(::Protobuf::Field::MessageField) && value.respond_to?(:to_hash)

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -21,6 +21,22 @@ module Protobuf
       name
     end
 
+    def self.from_json(json)
+      fields = normalize_json(JSON.parse(json))
+      self.new(fields)
+    end
+
+    def self.normalize_json(ob)
+      case ob
+      when Array
+        ob.map {|value| normalize_json(value) }
+      when Hash
+        Hash[*ob.flat_map {|key, value| [key.underscore, normalize_json(value)] }]
+      else
+        ob
+      end
+    end
+
     ##
     # Constructor
     #

--- a/spec/lib/protobuf/message_spec.rb
+++ b/spec/lib/protobuf/message_spec.rb
@@ -439,6 +439,26 @@ RSpec.describe Protobuf::Message do
     end
   end
 
+  describe '.from_json' do
+    it 'decodes optional bytes field with base64' do
+      expected_single_bytes = "\x06\x8D1HP\x17:b".unpack('C*')
+      single_bytes = ::Test::ResourceFindRequest
+        .from_json('{"singleBytes":"Bo0xSFAXOmI="}')
+        .single_bytes.unpack('C*')
+
+      expect(single_bytes).to(eq(expected_single_bytes))
+    end
+
+    it 'decodes repeated bytes field with base64' do
+      expected_widget_bytes = ["\x06\x8D1HP\x17:b"].map {|s| s.unpack('C*')}
+      widget_bytes = ::Test::ResourceFindRequest
+        .from_json('{"widgetBytes":["Bo0xSFAXOmI="]}')
+        .widget_bytes.map {|s| s.unpack('C*')}
+
+      expect(widget_bytes).to(eq(expected_widget_bytes))
+    end
+  end
+
   describe '.to_json' do
     it 'returns the class name of the message for use in json encoding' do
       expect do

--- a/spec/support/protos/resource.pb.rb
+++ b/spec/support/protos/resource.pb.rb
@@ -72,6 +72,7 @@ module Test
     optional :bool, :active, 2
     repeated :string, :widgets, 3
     repeated :bytes, :widget_bytes, 4
+    optional :bytes, :single_bytes, 5
   end
 
   class ResourceSleepRequest
@@ -169,4 +170,3 @@ module Test
   end
 
 end
-

--- a/spec/support/protos/resource.proto
+++ b/spec/support/protos/resource.proto
@@ -47,6 +47,7 @@ message ResourceFindRequest {
   optional bool active = 2;
   repeated string widgets = 3;
   repeated bytes widget_bytes = 4;
+  optional bytes single_bytes = 5;
 }
 
 message ResourceSleepRequest {


### PR DESCRIPTION
This PR adds a new `Message.from_json` class method that turns a JSON string into a message object.

It addresses two shortcomings:

* Lower camel case field names (`fooBarZap`) in the JSON are converted to underscore (`fooBarZap`)
* Values for `bytes` fields are Base64 decoded unless they are already in "binary" format. This is because Protobuf's JSON representation uses Base64 encoding for bytes fields. 