### PR TITLE
Remove all EOL except 2.3; Add 2.6/2.7 and latest jruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,12 @@ before_install:
   - gem update bundler
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
   - 2.3
-  - 2.4
   - 2.5
+  - 2.6
+  - 2.7
   - jruby-9.1.17.0
-  - jruby-9.2.5.0
+  - jruby-9.2.9.0
   - rbx-2
 env:
   - PROTOBUF_VERSION=2.6.1


### PR DESCRIPTION
Ruby 1.9.3 was failing on the current version of json, which is strange. Most of the versions in the rvm matrix have been EOL'd for a while now. This updates the matrix.

cc @abrandoned @liveh2o 