### PR TITLE
64bit integer as json string

### DIFF
--- a/lib/protobuf/field/int64_field.rb
+++ b/lib/protobuf/field/int64_field.rb
@@ -29,6 +29,9 @@ module Protobuf
         return false
       end
 
+      def json_encode(value)
+        value == 0 ? nil : value.to_s
+      end
     end
   end
 end

--- a/lib/protobuf/field/sint64_field.rb
+++ b/lib/protobuf/field/sint64_field.rb
@@ -16,6 +16,9 @@ module Protobuf
         INT64_MIN
       end
 
+      def json_encode(value)
+        value == 0 ? nil : value.to_s
+      end
     end
   end
 end

--- a/lib/protobuf/field/uint64_field.rb
+++ b/lib/protobuf/field/uint64_field.rb
@@ -16,6 +16,9 @@ module Protobuf
         0
       end
 
+      def json_encode(value)
+        value == 0 ? nil : value.to_s
+      end
     end
   end
 end

--- a/lib/protobuf/message.rb
+++ b/lib/protobuf/message.rb
@@ -156,7 +156,11 @@ module Protobuf
                          value
                        end
 
-        result[field.name] = hashed_value
+        if hashed_value.nil?
+          result.delete(field.name)
+        else
+          result[field.name] = hashed_value
+        end
       end
 
       result

--- a/spec/lib/protobuf/field/fixed64_field_spec.rb
+++ b/spec/lib/protobuf/field/fixed64_field_spec.rb
@@ -4,4 +4,27 @@ RSpec.describe Protobuf::Field::Fixed64Field do
 
   it_behaves_like :packable_field, described_class
 
+  let(:message) do
+    Class.new(::Protobuf::Message) do
+      optional :fixed64, :field, 1
+    end
+  end
+
+  # https://developers.google.com/protocol-buffers/docs/proto3#json
+  describe '.{to_json, from_json}' do
+    it 'serialises 0 as empty' do
+      instance = message.new(:field => 0)
+      expect(instance.to_json).to eq('{}')
+    end
+
+    it 'serialises max value as string' do
+      instance = message.new(:field => described_class.max)
+      expect(instance.to_json).to eq('{"field":"18446744073709551615"}')
+    end
+
+    it 'serialises min value as string' do
+      instance = message.new(:field => described_class.min)
+      expect(instance.to_json).to eq('{}')
+    end
+  end
 end

--- a/spec/lib/protobuf/field/int64_field_spec.rb
+++ b/spec/lib/protobuf/field/int64_field_spec.rb
@@ -4,4 +4,17 @@ RSpec.describe Protobuf::Field::Int64Field do
 
   it_behaves_like :packable_field, described_class
 
+  let(:message) do
+    Class.new(::Protobuf::Message) do
+      optional :int64, :field, 1
+    end
+  end
+
+  # https://developers.google.com/protocol-buffers/docs/proto3#json
+  describe '.{to_json, from_json}' do
+    it 'serialises int64 value as string' do
+      instance = message.new(:field => 10)
+      expect(instance.to_json).to eq('{"field":"10"}')
+    end
+  end
 end

--- a/spec/lib/protobuf/field/int64_field_spec.rb
+++ b/spec/lib/protobuf/field/int64_field_spec.rb
@@ -12,9 +12,19 @@ RSpec.describe Protobuf::Field::Int64Field do
 
   # https://developers.google.com/protocol-buffers/docs/proto3#json
   describe '.{to_json, from_json}' do
-    it 'serialises int64 value as string' do
-      instance = message.new(:field => 10)
-      expect(instance.to_json).to eq('{"field":"10"}')
+    it 'serialises 0 as empty' do
+      instance = message.new(:field => 0)
+      expect(instance.to_json).to eq('{}')
+    end
+
+    it 'serialises max value as string' do
+      instance = message.new(:field => described_class.max)
+      expect(instance.to_json).to eq('{"field":"9223372036854775807"}')
+    end
+
+    it 'serialises min value as string' do
+      instance = message.new(:field => described_class.min)
+      expect(instance.to_json).to eq('{"field":"-9223372036854775808"}')
     end
   end
 end

--- a/spec/lib/protobuf/field/sfixed64_field_spec.rb
+++ b/spec/lib/protobuf/field/sfixed64_field_spec.rb
@@ -6,4 +6,27 @@ RSpec.describe Protobuf::Field::Sfixed64Field do
     let(:value) { [-1, 0, 1] }
   end
 
+  let(:message) do
+    Class.new(::Protobuf::Message) do
+      optional :sfixed64, :field, 1
+    end
+  end
+
+  # https://developers.google.com/protocol-buffers/docs/proto3#json
+  describe '.{to_json, from_json}' do
+    it 'serialises 0 as empty' do
+      instance = message.new(:field => 0)
+      expect(instance.to_json).to eq('{}')
+    end
+
+    it 'serialises max value as string' do
+      instance = message.new(:field => described_class.max)
+      expect(instance.to_json).to eq('{"field":"9223372036854775807"}')
+    end
+
+    it 'serialises min value as string' do
+      instance = message.new(:field => described_class.min)
+      expect(instance.to_json).to eq('{"field":"-9223372036854775808"}')
+    end
+  end
 end

--- a/spec/lib/protobuf/field/sint64_field_spec.rb
+++ b/spec/lib/protobuf/field/sint64_field_spec.rb
@@ -6,4 +6,27 @@ RSpec.describe Protobuf::Field::Sint64Field do
     let(:value) { [-1, 0, 1] }
   end
 
+  let(:message) do
+    Class.new(::Protobuf::Message) do
+      optional :sint64, :field, 1
+    end
+  end
+
+  # https://developers.google.com/protocol-buffers/docs/proto3#json
+  describe '.{to_json, from_json}' do
+    it 'serialises 0 as empty' do
+      instance = message.new(:field => 0)
+      expect(instance.to_json).to eq('{}')
+    end
+
+    it 'serialises max value as string' do
+      instance = message.new(:field => described_class.max)
+      expect(instance.to_json).to eq('{"field":"9223372036854775807"}')
+    end
+
+    it 'serialises min value as string' do
+      instance = message.new(:field => described_class.min)
+      expect(instance.to_json).to eq('{"field":"-9223372036854775808"}')
+    end
+  end
 end

--- a/spec/lib/protobuf/field/uint64_field_spec.rb
+++ b/spec/lib/protobuf/field/uint64_field_spec.rb
@@ -4,4 +4,27 @@ RSpec.describe Protobuf::Field::Uint64Field do
 
   it_behaves_like :packable_field, described_class
 
+  let(:message) do
+    Class.new(::Protobuf::Message) do
+      optional :uint64, :field, 1
+    end
+  end
+
+  # https://developers.google.com/protocol-buffers/docs/proto3#json
+  describe '.{to_json, from_json}' do
+    it 'serialises 0 as empty' do
+      instance = message.new(:field => 0)
+      expect(instance.to_json).to eq('{}')
+    end
+
+    it 'serialises max value as string' do
+      instance = message.new(:field => described_class.max)
+      expect(instance.to_json).to eq('{"field":"18446744073709551615"}')
+    end
+
+    it 'serialises min value as string' do
+      instance = message.new(:field => described_class.min)
+      expect(instance.to_json).to eq('{}')
+    end
+  end
 end


### PR DESCRIPTION
This patch fixes incorrect encoding of 64 bit integers, which, according to the [official protobuf docs](https://developers.google.com/protocol-buffers/docs/proto3#json) must be encoded as a string.

It also removes fields that have the default value (such as `0` for numbers).