### PR TITLE
Add support for v3 protos with optional fields

### DIFF
--- a/lib/protobuf/code_generator.rb
+++ b/lib/protobuf/code_generator.rb
@@ -46,7 +46,16 @@ module Protobuf
         generate_file(file_descriptor)
       end
 
-      ::Google::Protobuf::Compiler::CodeGeneratorResponse.encode(:file => generated_files)
+      ::Google::Protobuf::Compiler::CodeGeneratorResponse.encode(
+        :file => generated_files,
+        :supported_features => supported_features,
+      )
+    end
+
+    def supported_features
+      # The only available feature is proto3 with optional fields.
+      # This is backwards compatible with proto2 optional fields.
+      ::Google::Protobuf::Compiler::CodeGeneratorResponse::Feature::FEATURE_PROTO3_OPTIONAL.to_i
     end
 
     Protobuf::Field::BaseField.module_eval do

--- a/lib/protobuf/descriptors/google/protobuf/compiler/plugin.pb.rb
+++ b/lib/protobuf/descriptors/google/protobuf/compiler/plugin.pb.rb
@@ -21,6 +21,11 @@ module Google
       #
       class CodeGeneratorRequest < ::Protobuf::Message; end
       class CodeGeneratorResponse < ::Protobuf::Message
+        class Feature < ::Protobuf::Enum
+          define :FEATURE_NONE, 0
+          define :FEATURE_PROTO3_OPTIONAL, 1
+        end
+
         class File < ::Protobuf::Message; end
 
       end
@@ -51,6 +56,7 @@ module Google
         end
 
         optional :string, :error, 1
+        optional :uint64, :supported_features, 2
         repeated ::Google::Protobuf::Compiler::CodeGeneratorResponse::File, :file, 15
       end
 

--- a/proto/google/protobuf/compiler/plugin.proto
+++ b/proto/google/protobuf/compiler/plugin.proto
@@ -88,6 +88,16 @@ message CodeGeneratorResponse {
   // exiting with a non-zero status code.
   optional string error = 1;
 
+  // A bitmask of supported features that the code generator supports.
+  // This is a bitwise "or" of values from the Feature enum.
+  optional uint64 supported_features = 2;
+
+  // Sync with code_generator.h.
+  enum Feature {
+    FEATURE_NONE = 0;
+    FEATURE_PROTO3_OPTIONAL = 1;
+  }
+
   // Represents a single generated file.
   message File {
     // The file name, relative to the output directory.  The name must not

--- a/spec/functional/code_generator_spec.rb
+++ b/spec/functional/code_generator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'code generation' do
     end
 
     expected_output =
-      ::Google::Protobuf::Compiler::CodeGeneratorResponse.encode(:file => expected_file_descriptors)
+      ::Google::Protobuf::Compiler::CodeGeneratorResponse.encode(:file => expected_file_descriptors, :supported_features => 1)
 
     code_generator = ::Protobuf::CodeGenerator.new(bytes)
     code_generator.eval_unknown_extensions!
@@ -37,7 +37,7 @@ RSpec.describe 'code generation' do
         :name => file_name, :content => file_content)
 
     expected_response =
-      ::Google::Protobuf::Compiler::CodeGeneratorResponse.encode(:file => [expected_file_output])
+      ::Google::Protobuf::Compiler::CodeGeneratorResponse.encode(:file => [expected_file_output], :supported_features => 1)
 
     code_generator = ::Protobuf::CodeGenerator.new(request.encode)
     code_generator.eval_unknown_extensions!

--- a/spec/lib/protobuf/code_generator_spec.rb
+++ b/spec/lib/protobuf/code_generator_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ::Protobuf::CodeGenerator do
     end
 
     let(:expected_response_bytes) do
-      COMPILER::CodeGeneratorResponse.encode(:file => [output_file1, output_file2])
+      COMPILER::CodeGeneratorResponse.encode(:file => [output_file1, output_file2], :supported_features => 1)
     end
 
     before do

--- a/spec/support/protos/optional_v3_fields.pb.rb
+++ b/spec/support/protos/optional_v3_fields.pb.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+
+##
+# This file is auto-generated. DO NOT EDIT!
+#
+require 'protobuf'
+
+
+##
+# Message Classes
+#
+class SomethingWithOptionalFields < ::Protobuf::Message; end
+
+
+##
+# Message Fields
+#
+class SomethingWithOptionalFields
+  optional :string, :i_am_optional, 1
+  optional :string, :i_am_not_optional, 2
+end
+

--- a/spec/support/protos/optional_v3_fields.proto
+++ b/spec/support/protos/optional_v3_fields.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message SomethingWithOptionalFields {
+  optional string i_am_optional = 1;
+  string i_am_not_optional      = 2;
+}


### PR DESCRIPTION
This PR adds support for compiling v3 proto definitions with optional fields. The tl;dr is that optional fields are nullable fields. It should be wire compatible with v2 optional fields. Can a reviewer double-check me here? Here's the google reference: https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf/+/refs/heads/master/docs/implementing_proto3_presence.md

How do we support v3 protos with optional fields? Turns out it's pretty easy. Mainline protobuf added a new field on `plugin.proto` that communicates with features are enabled. Currently there's only one feature, v3 protos with optional fields, but this should be pretty easy to modify going forward.

~~Most of the diff is getting `bx rake` to rebuild proto files in `spec/support` without silently failing. I re-wrote rake to fail when a proto command fails. I also added some `pb.rb` definitions that were being generated but were not committed. At this point, running `bx rake` should do what you expect: recompile support definitions, run rspec, and then run rubocop.~~ (Update: this has been applied in a different PR).

At MX we have a few golang services that are compiling proto3 definitions that need nullable fields. In order to share definitions, we need to add support for this new v3 optional proto field feature in ruby-protobuf. Since ruby-protobuf with v3 seems to work and implicitly makes all v3 proto fields optional, this change should be harmless. But again, please check me on this.

@abrandoned @quixoten 