### PR TITLE
Ensure server is always set on a response proto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,5 @@ workflows:
               ruby-image:
                 - circleci/jruby:9.2.6.0-jdk
                 - circleci/jruby:9.1.17.0-jdk
-                - circleci/jruby:9.2-jdk8
-                - circleci/ruby:2.4
                 - circleci/ruby:2.5
                 - circleci/ruby:2.7

--- a/lib/protobuf/rpc/error.rb
+++ b/lib/protobuf/rpc/error.rb
@@ -18,7 +18,7 @@ module Protobuf
       end
 
       def to_response(args = {})
-        ::Protobuf::Socketrpc::Response.new({:error => message, :error_reason => error_type}.merge(args))
+        ::Protobuf::Socketrpc::Response.new({ :error => message, :error_reason => error_type }.merge(args))
       end
     end
   end

--- a/lib/protobuf/rpc/error.rb
+++ b/lib/protobuf/rpc/error.rb
@@ -13,12 +13,12 @@ module Protobuf
         super message
       end
 
-      def encode
-        to_response.encode
+      def encode(args = {})
+        to_response(args).encode
       end
 
-      def to_response
-        ::Protobuf::Socketrpc::Response.new(:error => message, :error_reason => error_type)
+      def to_response(args = {})
+        ::Protobuf::Socketrpc::Response.new({:error => message, :error_reason => error_type}.merge(args))
       end
     end
   end

--- a/spec/lib/protobuf/rpc/middleware/exception_handler_spec.rb
+++ b/spec/lib/protobuf/rpc/middleware/exception_handler_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Protobuf::Rpc::Middleware::ExceptionHandler do
   let(:app) { proc { |env| env } }
-  let(:env) { Protobuf::Rpc::Env.new }
+  let(:env) { Protobuf::Rpc::Env.new("server" => "cooldude") }
 
   subject { described_class.new(app) }
 
@@ -17,7 +17,7 @@ RSpec.describe Protobuf::Rpc::Middleware::ExceptionHandler do
     end
 
     context "when exceptions occur" do
-      let(:encoded_error) { error.encode }
+      let(:encoded_error) { error.encode(:server => "cooldude") }
       let(:error) { Protobuf::Rpc::MethodNotFound.new('Boom!') }
 
       before { allow(app).to receive(:call).and_raise(error, 'Boom!') }
@@ -42,7 +42,7 @@ RSpec.describe Protobuf::Rpc::Middleware::ExceptionHandler do
       end
 
       context "when exception is not a Protobuf error" do
-        let(:encoded_error) { error.encode }
+        let(:encoded_error) { error.encode(:server => "cooldude") }
         let(:error) { Protobuf::Rpc::RpcFailed.new('Boom!') }
 
         before { allow(app).to receive(:call).and_raise(RuntimeError, 'Boom!') }

--- a/spec/lib/protobuf/rpc/stat_spec.rb
+++ b/spec/lib/protobuf/rpc/stat_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'timecop'
-require 'active_support/core_ext/numeric/time'
+require 'active_support/all'
 
 RSpec.describe ::Protobuf::Rpc::Stat do
 


### PR DESCRIPTION
The scenario was that we found `PbError` in the exception handler middleware does not set the `server` from the `env`, but it does do it in the response encoder middleware. It seems appropriate to add it to the exception handler middleware as well because without this, a `fail RuntimeError, "yolo"` would not have a server hostname, and would display the default host/port combo defined in the base connector class which is `127.0.0.1:9399` which is almost always wrong, unless you're actually using the socket connector, which to my knowledge, nobody is.

Thanks @moveson for helping!