### PR TITLE
Require `active_support` before cherry-picking features

### DIFF
--- a/lib/protobuf.rb
+++ b/lib/protobuf.rb
@@ -4,6 +4,7 @@ require 'pp'
 require 'socket'
 require 'stringio'
 
+require 'active_support'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/try'
 require 'active_support/inflector'

--- a/lib/protobuf/cli.rb
+++ b/lib/protobuf/cli.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/hash/keys'
 require 'active_support/inflector'
 

--- a/lib/protobuf/code_generator.rb
+++ b/lib/protobuf/code_generator.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/module/aliasing'
 require 'protobuf/generators/file_generator'
 

--- a/lib/protobuf/deprecation.rb
+++ b/lib/protobuf/deprecation.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/deprecation'
 
 module Protobuf

--- a/lib/protobuf/field/base_field.rb
+++ b/lib/protobuf/field/base_field.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/hash/slice'
 require 'protobuf/field/field_array'
 require 'protobuf/field/field_hash'

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -1,5 +1,6 @@
 require 'ostruct'
 
+require 'active_support'
 require 'active_support/core_ext/hash/reverse_merge'
 
 require 'spec_helper'


### PR DESCRIPTION
It's part of the Active Support contract, the entry point must be loaded, otherwise requiring individual components may fail.

Fixes:

```
active_support/core_ext/time/conversions.rb:62:in `<class:Time>': undefined method `deprecator' for ActiveSupport:Module (NoMethodError)
	from gems/activesupport-7.1.1/lib/active_support/core_ext/time/conversions.rb:7:in `<top (required)>'
	from gems/activesupport-7.1.1/lib/active_support/core_ext/object/json.rb:14:in `require'
	from gems/activesupport-7.1.1/lib/active_support/core_ext/object/json.rb:14:in `<top (required)>'
	from gems/activesupport-7.1.1/lib/active_support/json/encoding.rb:3:in `require'
	from gems/activesupport-7.1.1/lib/active_support/json/encoding.rb:3:in `<top (required)>'
	from gems/activesupport-7.1.1/lib/active_support/json.rb:4:in `require'
	from gems/activesupport-7.1.1/lib/active_support/json.rb:4:in `<top (required)>'
	from gems/protobuf-cucumber-3.10.8/lib/protobuf.rb:10:in `require'
```